### PR TITLE
Add Restdocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.4.3'
 	id 'io.spring.dependency-management' version '1.1.7'
+	id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'seondays'
@@ -17,6 +18,7 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+	asciidoctorExt
 }
 
 repositories {
@@ -52,8 +54,37 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// RestDocs
+	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+ext {
+	snippetsDir = file('build/generated-snippets')
+}
+
+test {
+	outputs.dir snippetsDir
+}
+
+asciidoctor {
+	inputs.dir snippetsDir
+	configurations 'asciidoctorExt'
+
+	sources {
+		include("**/index.adoc")
+	}
+	baseDirFollowsSourceFile()
+	dependsOn test
+}
+
+bootJar {
+	dependsOn asciidoctor
+	from("${asciidoctor.outputDir}") {
+		into 'static/docs'
+	}
 }

--- a/src/docs/asciidoc/api/voucher/voucher.adoc
+++ b/src/docs/asciidoc/api/voucher/voucher.adoc
@@ -1,0 +1,46 @@
+[[voucher-create]]
+=== 쿠폰 등록
+
+==== HTTP Request
+include::{snippets}/voucher-create/http-request.adoc[]
+==== Multipart info
+include::{snippets}/voucher-create/request-parts.adoc[]
+include::{snippets}/voucher-create/request-part-request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/voucher-create/http-response.adoc[]
+include::{snippets}/voucher-create/response-fields.adoc[]
+
+[[voucher-delete]]
+=== 쿠폰 삭제
+
+==== HTTP Request
+include::{snippets}/voucher-delete/http-request.adoc[]
+include::{snippets}/voucher-delete/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/voucher-delete/http-response.adoc[]
+
+[[voucher-get]]
+=== 쿠폰 조회
+
+==== HTTP Request
+include::{snippets}/voucher-get/http-request.adoc[]
+include::{snippets}/voucher-get/path-parameters.adoc[]
+include::{snippets}/voucher-get/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/voucher-get/http-response.adoc[]
+include::{snippets}/voucher-get/response-fields.adoc[]
+
+[[voucherStatus-change]]
+=== 쿠폰 상태 변경
+
+==== HTTP Request
+include::{snippets}/voucherStatus-change/http-request.adoc[]
+include::{snippets}/voucherStatus-change/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/voucherStatus-change/http-response.adoc[]
+
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,16 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+
+= Shareticon REST API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[Voucher-API]]
+== Voucher API
+
+include::api/voucher/voucher.adoc[]

--- a/src/main/java/seondays/shareticon/exception/handler/CustomExceptionHandler.java
+++ b/src/main/java/seondays/shareticon/exception/handler/CustomExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MultipartException;
 import seondays.shareticon.exception.ExpiredVoucherException;
 import seondays.shareticon.exception.GroupNotFoundException;
 import seondays.shareticon.exception.IllegalOAuthProviderException;
@@ -146,9 +147,18 @@ public class CustomExceptionHandler {
         return createExceptionResponse(message, HttpStatus.UNAUTHORIZED);
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<CustomExceptionResponse> bindException(Exception e) {
+    @ExceptionHandler(MultipartException.class)
+    public ResponseEntity<CustomExceptionResponse> handleMultipartException(
+            MultipartException e) {
         log.error(String.valueOf(e));
+
+        String message = "해당 요청은 multipart/form-data 형식으로만 지원됩니다. 파일을 첨부하여 다시 시도해주세요";
+        return createExceptionResponse(message, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CustomExceptionResponse> generalException(Exception e) {
+        log.error("{} : {}", e.getMessage(), e);
 
         final String message = "서버 오류가 발생했습니다";
         return createExceptionResponse(message, HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/seondays/shareticon/voucher/VoucherController.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherController.java
@@ -34,7 +34,7 @@ public class VoucherController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<VouchersResponse> registerVoucher(
             @AuthenticationPrincipal CustomOAuth2User userDetails,
-            @RequestPart("groupId") @Valid CreateVoucherRequest request,
+            @RequestPart("request") @Valid CreateVoucherRequest request,
             @RequestPart("image") MultipartFile image) {
         Long userId = userDetails.getId();
         VouchersResponse response = voucherService.register(request, userId, image);

--- a/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
+++ b/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
@@ -1,0 +1,41 @@
+package seondays.shareticon.docs;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import seondays.shareticon.login.CustomOAuth2User;
+import seondays.shareticon.user.dto.UserOAuth2Dto;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsSupport {
+
+    protected MockMvc mockMvc;
+    protected ObjectMapper objectMapper = new ObjectMapper();
+    protected CustomOAuth2User mockUser;
+    protected Authentication auth;
+
+    @BeforeEach
+    void setUp(RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
+                .apply(documentationConfiguration(provider))
+                .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .build();
+
+        mockUser = new CustomOAuth2User(new UserOAuth2Dto(1L, "user", "ROLE_USER"));
+        auth = new UsernamePasswordAuthenticationToken(
+                mockUser, mockUser.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    protected abstract Object initController();
+}

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -1,0 +1,254 @@
+package seondays.shareticon.docs.voucher;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.multipart.MultipartFile;
+import seondays.shareticon.docs.RestDocsSupport;
+import seondays.shareticon.voucher.VoucherController;
+import seondays.shareticon.voucher.VoucherService;
+import seondays.shareticon.voucher.VoucherStatus;
+import seondays.shareticon.voucher.dto.CreateVoucherRequest;
+import seondays.shareticon.voucher.dto.VouchersResponse;
+
+public class VoucherControllerDocsTest extends RestDocsSupport {
+
+    private final VoucherService voucherService = mock(VoucherService.class);
+
+    @Override
+    protected Object initController() {
+        return new VoucherController(voucherService);
+    }
+
+    @Test
+    @DisplayName("신규 쿠폰을 생성한다")
+    void registerVoucher() throws Exception {
+        //given
+        CreateVoucherRequest request = new CreateVoucherRequest(1L);
+        String jsonRequest = objectMapper.writeValueAsString(request);
+
+        MockMultipartFile imagePart = new MockMultipartFile(
+                "image",
+                "voucherImage.jpg",
+                "image/jpeg",
+                "voucherImage".getBytes()
+        );
+
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request",
+                null,
+                "application/json",
+                jsonRequest.getBytes(StandardCharsets.UTF_8)
+        );
+
+        VouchersResponse mockResponse = new VouchersResponse(1L, "voucherImage",
+                VoucherStatus.AVAILABLE);
+
+        when(voucherService.register(
+                any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
+                .thenReturn(mockResponse);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.multipart("/vouchers")
+                                .file(imagePart)
+                                .file(requestPart)
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(header().string("Location", "/vouchers/1"))
+                .andExpect(jsonPath("$.id").value(1L))
+                .andExpect(jsonPath("$.status").value("AVAILABLE"))
+                .andDo(document("voucher-create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestParts(
+                                partWithName("request").description("쿠폰 생성 request"),
+                                partWithName("image").description("쿠폰 이미지 파일")
+                        ),
+                        requestPartFields("request",
+                                fieldWithPath("groupId").type(JsonFieldType.NUMBER)
+                                        .description("쿠폰을 저장할 그룹 ID")
+                        ),
+                        responseFields(
+
+                                fieldWithPath("id").type(JsonFieldType.NUMBER)
+                                        .description("생성된 쿠폰 ID"),
+                                fieldWithPath("image").type(JsonFieldType.STRING)
+                                        .description("이미지 URL"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("쿠폰 상태 (AVAILABLE/EXPIRED/USED)")
+
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("쿠폰을 삭제한다")
+    void deleteVoucher() throws Exception {
+        //given
+        Long groupId = 1L;
+        Long voucherId = 1L;
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.delete("/vouchers/group/{groupId}/voucher/{voucherId}",
+                                        groupId, voucherId)
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(document("voucher-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("groupId").description("쿠폰이 속한 그룹 ID"),
+                                parameterWithName("voucherId").description("삭제할 쿠폰 ID")
+                        )));
+    }
+
+    @Test
+    @DisplayName("페이징을 포함하여 그룹에 등록된 전체 쿠폰을 조회한다")
+    void getAllVoucherInGroup() throws Exception {
+        //given
+        Long groupId = 1L;
+        Long cursorId = 1L;
+        int pageSize = 1;
+
+        Slice<VouchersResponse> mockSlice =
+                new SliceImpl<>(Collections.emptyList(), PageRequest.of(0, pageSize), false);
+
+        when(voucherService.getAllVoucher(eq(mockUser.getId()), eq(groupId), eq(cursorId),
+                eq(pageSize)))
+                .thenReturn(mockSlice);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/vouchers/{groupId}", groupId)
+                                .param("cursorId", cursorId.toString())
+                                .param("pageSize", String.valueOf(pageSize))
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.pageable").exists())
+                .andExpect(jsonPath("$.pageable.pageSize").value(pageSize))
+                .andExpect(jsonPath("$.size").value(pageSize))
+                .andDo(document("voucher-get",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("groupId").description("쿠폰을 조회하고자 하는 그룹 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("cursorId").description("커서 ID 값").optional(),
+                                parameterWithName("pageSize").description("페이지 사이즈 값 (기본값 10)")
+                                        .optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("content").type(JsonFieldType.ARRAY)
+                                        .description("조회된 쿠폰 객체들의 배열"),
+
+                                // 2) 페이징 요청 정보(중첩 객체)
+                                subsectionWithPath("pageable").type(JsonFieldType.OBJECT)
+                                        .description("페이지네이션 요청 정보"),
+                                fieldWithPath("pageable.pageNumber").type(JsonFieldType.NUMBER)
+                                        .description("현재 페이지 번호"),
+                                fieldWithPath("pageable.pageSize").type(JsonFieldType.NUMBER)
+                                        .description("요청된 페이지 크기"),
+                                subsectionWithPath("pageable.sort").type(JsonFieldType.OBJECT)
+                                        .description("요청된 정렬 정보"),
+                                fieldWithPath("pageable.sort.empty").type(JsonFieldType.BOOLEAN)
+                                        .description("정렬 기준 존재 여부"),
+                                fieldWithPath("pageable.sort.sorted").type(JsonFieldType.BOOLEAN)
+                                        .description("정렬이 적용되었는지 여부"),
+                                fieldWithPath("pageable.sort.unsorted").type(JsonFieldType.BOOLEAN)
+                                        .description("정렬이 적용되지 않았는지 여부"),
+                                fieldWithPath("pageable.offset").type(JsonFieldType.NUMBER)
+                                        .description("요청 오프셋"),
+                                fieldWithPath("pageable.paged").type(JsonFieldType.BOOLEAN)
+                                        .description("페이지네이션이 적용되었는지 여부"),
+                                fieldWithPath("pageable.unpaged").type(JsonFieldType.BOOLEAN)
+                                        .description("페이지네이션이 적용되지 않았는지 여부"),
+
+                                fieldWithPath("size").type(JsonFieldType.NUMBER)
+                                        .description("페이지 크기"),
+                                fieldWithPath("number").type(JsonFieldType.NUMBER)
+                                        .description("현재 페이지 번호"),
+
+                                subsectionWithPath("sort").type(JsonFieldType.OBJECT)
+                                        .description("실제 적용된 정렬 정보"),
+                                fieldWithPath("sort.empty").type(JsonFieldType.BOOLEAN)
+                                        .description("정렬 기준 존재 여부"),
+                                fieldWithPath("sort.sorted").type(JsonFieldType.BOOLEAN)
+                                        .description("정렬이 적용되었는지 여부"),
+                                fieldWithPath("sort.unsorted").type(JsonFieldType.BOOLEAN)
+                                        .description("정렬이 적용되지 않았는지 여부"),
+
+                                fieldWithPath("first").type(JsonFieldType.BOOLEAN)
+                                        .description("첫 페이지인지 여부"),
+                                fieldWithPath("last").type(JsonFieldType.BOOLEAN)
+                                        .description("마지막 페이지인지 여부"),
+                                fieldWithPath("numberOfElements").type(JsonFieldType.NUMBER)
+                                        .description("현재 페이지에 실제 포함된 요소 개수"),
+                                fieldWithPath("empty").type(JsonFieldType.BOOLEAN)
+                                        .description("현재 페이지가 비어 있는지 여부")
+                        )));
+    }
+
+    @Test
+    @DisplayName("쿠폰의 상태를 변경한다")
+    void changeVoucherStatus() throws Exception {
+        //given
+        Long groupId = 1L;
+        Long voucherId = 1L;
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.patch("/vouchers/group/{groupId}/voucher/{voucherId}",
+                                        groupId, voucherId)
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(document("voucherStatus-change",
+                        pathParameters(
+                                parameterWithName("groupId").description("쿠폰이 속한 그룹 ID"),
+                                parameterWithName("voucherId").description("변경할 쿠폰 ID")
+                        )));
+    }
+}

--- a/src/test/java/seondays/shareticon/voucher/VoucherControllerTest.java
+++ b/src/test/java/seondays/shareticon/voucher/VoucherControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -28,7 +27,6 @@ import seondays.shareticon.voucher.dto.VouchersResponse;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
@@ -70,7 +68,7 @@ public class VoucherControllerTest {
 
         // requestPart로 들어갈 JSON mock
         MockMultipartFile requestPart = new MockMultipartFile(
-                "groupId",
+                "request",
                 null,
                 "application/json",
                 jsonRequest.getBytes(StandardCharsets.UTF_8)
@@ -111,7 +109,7 @@ public class VoucherControllerTest {
         );
 
         MockMultipartFile requestPart = new MockMultipartFile(
-                "groupId",
+                "request",
                 null,
                 "application/json",
                 emptyRequest.getBytes(StandardCharsets.UTF_8)

--- a/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
@@ -6,7 +6,7 @@
 
 |{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
-|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{^optional}}X{{/optional}}{{/tableCellContent}}
 
 {{/parameters}}
 

--- a/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
@@ -1,0 +1,13 @@
+==== Query parameters
+|===
+|Name|Description|Optional
+
+{{#parameters}}
+
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+
+{{/parameters}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,14 @@
+==== Request Fields
+|===
+|Path|Type|Description|Optional
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -7,7 +7,7 @@
 |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
-|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{^optional}}X{{/optional}}{{/tableCellContent}}
 
 {{/fields}}
 

--- a/src/test/resources/org/springframework/restdocs/templates/request-part-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-part-fields.snippet
@@ -1,0 +1,14 @@
+==== Multipart Request Fields
+|===
+|Path|Type|Description|Optional
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-part-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-part-fields.snippet
@@ -7,7 +7,7 @@
 |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
-|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{^optional}}X{{/optional}}{{/tableCellContent}}
 
 {{/fields}}
 

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,14 @@
+==== Response Fields
+|===
+|Path|Type|Description|Optional
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -7,7 +7,7 @@
 |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
-|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{^optional}}X{{/optional}}{{/tableCellContent}}
 
 {{/fields}}
 


### PR DESCRIPTION
## 연관 이슈
#10 

## 작업 내용
1. API 문서화를 위해 Spring REST Docs 도입
    - `Voucher` 우선 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added comprehensive REST API documentation for voucher-related endpoints, including creation, deletion, retrieval, and status change.
  - Integrated automatic generation and packaging of REST Docs-based documentation into the application build.

- **Bug Fixes**
  - Improved error handling for multipart/form-data requests, providing clearer error messages for unsupported request types.

- **Documentation**
  - Introduced modular AsciiDoc files and custom snippet templates for consistent API documentation.
  - Main API documentation index now includes voucher API details and improved navigation.

- **Tests**
  - Added new test classes to generate and verify API documentation for voucher endpoints.
  - Updated tests to align with changes in multipart request part naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->