### PR TITLE
add Logout

### DIFF
--- a/src/docs/asciidoc/api/token/token.adoc
+++ b/src/docs/asciidoc/api/token/token.adoc
@@ -1,0 +1,12 @@
+[[token-reissue]]
+=== 엑세스 토큰 발급
+
+==== HTTP Request
+include::{snippets}/token-reissue/http-request.adoc[]
+==== Request Cookie
+include::{snippets}/token-reissue/request-cookies.adoc[]
+
+==== HTTP Response
+include::{snippets}/token-reissue/http-response.adoc[]
+==== Response Header
+include::{snippets}/token-reissue/response-headers.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -14,3 +14,8 @@ endif::[]
 == Voucher API
 
 include::api/voucher/voucher.adoc[]
+
+[[Token-API]]
+== Token API
+
+include::api/token/token.adoc[]

--- a/src/main/java/seondays/shareticon/config/SecurityConfig.java
+++ b/src/main/java/seondays/shareticon/config/SecurityConfig.java
@@ -31,8 +31,10 @@ public class SecurityConfig {
         http.httpBasic(AbstractHttpConfigurer::disable);
 
         // OAuth2
-        http.oauth2Login(oauth2 -> oauth2.userInfoEndpoint(userInfoEndpointConfig ->
-                        userInfoEndpointConfig.userService(oAuth2UserService))
+        http.oauth2Login(oauth2 -> oauth2
+                .loginPage("/oauth2/authorization/kakao")
+                .userInfoEndpoint(
+                        userInfoEndpointConfig -> userInfoEndpointConfig.userService(oAuth2UserService))
                 .successHandler(loginSuccessHandler));
 
         // stateless
@@ -51,8 +53,6 @@ public class SecurityConfig {
                 .jwt(jwt -> jwt.jwtAuthenticationConverter(
                         jwtAuthenticationConverter.convertToAuthentication()))
                         .authenticationEntryPoint(entryPoint));
-        
-        http.oauth2Login(oauth2 -> oauth2.loginPage("/oauth2/authorization/kakao"));
 
         return http.build();
     }

--- a/src/main/java/seondays/shareticon/config/SecurityConfig.java
+++ b/src/main/java/seondays/shareticon/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -25,10 +26,11 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        // disable csrf, formLogin, basic
+        // disable csrf, formLogin, basic, logout handler
         http.csrf(AbstractHttpConfigurer::disable);
         http.formLogin(AbstractHttpConfigurer::disable);
         http.httpBasic(AbstractHttpConfigurer::disable);
+        http.logout(LogoutConfigurer::disable);
 
         // OAuth2
         http.oauth2Login(oauth2 -> oauth2

--- a/src/main/java/seondays/shareticon/config/TokenTimeConfig.java
+++ b/src/main/java/seondays/shareticon/config/TokenTimeConfig.java
@@ -1,0 +1,14 @@
+package seondays.shareticon.config;
+
+import java.time.Clock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TokenTimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/seondays/shareticon/login/JwtAuthenticationConverter.java
+++ b/src/main/java/seondays/shareticon/login/JwtAuthenticationConverter.java
@@ -26,10 +26,10 @@ public class JwtAuthenticationConverter {
     }
 
     private UserOAuth2Dto createUserOAuth2DtoFromJwt(Jwt jwt) {
-        Long userId = jwt.getClaim("userId");
+        String userId = jwt.getSubject();
         String role = jwt.getClaim("role");
         String name = jwt.getClaim("name");
 
-        return UserOAuth2Dto.create(userId, name, role);
+        return UserOAuth2Dto.create(Long.parseLong(userId), name, role);
     }
 }

--- a/src/main/java/seondays/shareticon/login/LoginSuccessHandler.java
+++ b/src/main/java/seondays/shareticon/login/LoginSuccessHandler.java
@@ -15,14 +15,14 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import seondays.shareticon.login.token.RefreshToken;
+import seondays.shareticon.login.token.TokenFactory;
 import seondays.shareticon.login.token.TokenRepository;
-import seondays.shareticon.login.token.TokenService;
 
 @Component
 @RequiredArgsConstructor
 public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final TokenService tokenService;
+    private final TokenFactory tokenFactory;
     private final TokenRepository tokenRepository;
 
     @Override
@@ -35,7 +35,7 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
         GrantedAuthority authority = iterator.next();
         String role = authority.getAuthority();
 
-        RefreshToken refreshToken = tokenService.createRefreshToken(principal.getId(),
+        RefreshToken refreshToken = tokenFactory.createRefreshToken(principal.getId(),
                 UserRole.getUserRoleBy(role), Duration.ofDays(7));
         tokenRepository.save(refreshToken);
 

--- a/src/main/java/seondays/shareticon/login/OAuth2Type.java
+++ b/src/main/java/seondays/shareticon/login/OAuth2Type.java
@@ -3,6 +3,7 @@ package seondays.shareticon.login;
 import java.util.Arrays;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import seondays.shareticon.exception.IllegalOAuthProviderException;
 
 @Getter
 @RequiredArgsConstructor
@@ -14,8 +15,8 @@ public enum OAuth2Type {
 
     public static OAuth2Type getOAuth2TypeBy(String registrationId) {
         return Arrays.stream(OAuth2Type.values())
-                .filter(oAuth2Type -> oAuth2Type.registrationId.equals(registrationId)).findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(
-                        registrationId + "에 대응하는 OAuth2Type이 없습니다"));
+                .filter(t -> t.registrationId.equalsIgnoreCase(registrationId))
+                .findFirst()
+                .orElseThrow(IllegalOAuthProviderException::new);
     }
 }

--- a/src/main/java/seondays/shareticon/login/provider/OAuth2ProviderUserFactory.java
+++ b/src/main/java/seondays/shareticon/login/provider/OAuth2ProviderUserFactory.java
@@ -3,15 +3,20 @@ package seondays.shareticon.login.provider;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 import seondays.shareticon.exception.IllegalOAuthProviderException;
+import seondays.shareticon.login.OAuth2Type;
 
 @Component
 public class OAuth2ProviderUserFactory {
 
     public OAuth2Provider getOAuth2User(String registrationId, Map<String, Object> attributes) {
-        if ("kakao".equals(registrationId)) {
-            return new KakaoUser(attributes);
-        }
+        OAuth2Type providerType = OAuth2Type.getOAuth2TypeBy(registrationId);
 
-        throw new IllegalOAuthProviderException();
+        switch (providerType) {
+            case KAKAO:
+                return new KakaoUser(attributes);
+
+            default:
+                throw new IllegalOAuthProviderException();
+        }
     }
 }

--- a/src/main/java/seondays/shareticon/login/token/StoredRefreshToken.java
+++ b/src/main/java/seondays/shareticon/login/token/StoredRefreshToken.java
@@ -1,9 +1,11 @@
 package seondays.shareticon.login.token;
 
 public record StoredRefreshToken(Long id,
-                                 String expiration) {
+                                 String expiration,
+                                 String value) {
     public static StoredRefreshToken of(RefreshToken refreshToken) {
-        return new StoredRefreshToken(refreshToken.getUserId(), refreshToken.getExpiration());
+        return new StoredRefreshToken(refreshToken.getUserId(), refreshToken.getExpiration(),
+                refreshToken.getToken());
     }
 
 }

--- a/src/main/java/seondays/shareticon/login/token/TokenController.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenController.java
@@ -31,7 +31,7 @@ public class TokenController {
     public ResponseEntity<Void> logout(
             @AuthenticationPrincipal CustomOAuth2User userDetails) {
         Long userId = userDetails.getId();
-        tokenService.deleteRefreshToken(userId);
+        tokenService.deleteAllRefreshToken(userId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/seondays/shareticon/login/token/TokenController.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenController.java
@@ -6,8 +6,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+import seondays.shareticon.login.CustomOAuth2User;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +24,14 @@ public class TokenController {
         Cookie[] cookies = request.getCookies();
         String accessToken = tokenService.reissueAccessToken(cookies);
         response.setHeader("Authorization", accessToken);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(
+            @AuthenticationPrincipal CustomOAuth2User userDetails) {
+        Long userId = userDetails.getId();
+        tokenService.deleteRefreshToken(userId);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/seondays/shareticon/login/token/TokenFactory.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenFactory.java
@@ -6,7 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
 import org.springframework.security.oauth2.jwt.JwsHeader;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
-import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
 import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.stereotype.Component;
@@ -30,12 +29,11 @@ public class TokenFactory {
 
     private String createJwt(Long userId, UserRole role, TokenType tokenType, Duration expiresIn) {
         Instant now = Instant.now();
-
         JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).type("JWT").build();
         JwtClaimsSet claims = JwtClaimsSet.builder()
                 .issuedAt(now)
                 .expiresAt(now.plus(expiresIn))
-                .claim("userId", userId)
+                .subject(String.valueOf(userId))
                 .claim("role", role)
                 .claim("tokenType", tokenType)
                 .build();

--- a/src/main/java/seondays/shareticon/login/token/TokenFactory.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenFactory.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.login.token;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import seondays.shareticon.login.UserRole;
 public class TokenFactory {
 
     private final JwtEncoder jwtEncoder;
+    private final Clock clock;
 
     public String createAccessToken(Long userId, UserRole role, Duration expiresIn) {
         String jwt = createJwt(userId, role, TokenType.ACCESS, expiresIn);
@@ -28,7 +30,7 @@ public class TokenFactory {
     }
 
     private String createJwt(Long userId, UserRole role, TokenType tokenType, Duration expiresIn) {
-        Instant now = Instant.now();
+        Instant now = clock.instant();
         JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).type("JWT").build();
         JwtClaimsSet claims = JwtClaimsSet.builder()
                 .issuedAt(now)

--- a/src/main/java/seondays/shareticon/login/token/TokenFactory.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenFactory.java
@@ -1,0 +1,49 @@
+package seondays.shareticon.login.token;
+
+import java.time.Duration;
+import java.time.Instant;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Component;
+import seondays.shareticon.login.UserRole;
+
+@Component
+@RequiredArgsConstructor
+public class TokenFactory {
+
+    private final JwtEncoder jwtEncoder;
+
+    public String createAccessToken(Long userId, UserRole role, Duration expiresIn) {
+        String jwt = createJwt(userId, role, TokenType.ACCESS, expiresIn);
+        return addBearerPrefix(jwt);
+    }
+
+    public RefreshToken createRefreshToken(Long userId, UserRole role, Duration expiresIn) {
+        String jwt = createJwt(userId, role, TokenType.REFRESH, expiresIn);
+        return RefreshToken.create(userId, jwt, expiresIn.getSeconds());
+    }
+
+    private String createJwt(Long userId, UserRole role, TokenType tokenType, Duration expiresIn) {
+        Instant now = Instant.now();
+
+        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).type("JWT").build();
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuedAt(now)
+                .expiresAt(now.plus(expiresIn))
+                .claim("userId", userId)
+                .claim("role", role)
+                .claim("tokenType", tokenType)
+                .build();
+
+        return jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
+    }
+
+    private String addBearerPrefix(String token) {
+        return "Bearer " + token;
+    }
+}

--- a/src/main/java/seondays/shareticon/login/token/TokenRepository.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenRepository.java
@@ -18,10 +18,16 @@ public class TokenRepository {
      * @param refreshToken
      */
     public void save(RefreshToken refreshToken) {
-        String key = makeKey(refreshToken.getToken());
+        String key = makeTokenKey(refreshToken.getToken());
+        String userKey = makeUserIdKey(refreshToken.getUserId());
+        StoredRefreshToken saveToken = StoredRefreshToken.of(refreshToken);
+
         redisTemplate.opsForValue()
-                .set(key, StoredRefreshToken.of(refreshToken),
+                .set(key, saveToken,
                         refreshToken.getTimeToLive(), TimeUnit.SECONDS);
+
+        redisTemplate.opsForSet().add(userKey, saveToken);
+        redisTemplate.expire(userKey, refreshToken.getTimeToLive(), TimeUnit.SECONDS);
     }
 
     /**
@@ -46,7 +52,7 @@ public class TokenRepository {
      * @return
      */
     public boolean existsById(String token) {
-        String key = makeKey(token);
+        String key = makeTokenKey(token);
         return Boolean.TRUE.equals(redisTemplate.hasKey(key));
     }
 

--- a/src/main/java/seondays/shareticon/login/token/TokenService.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenService.java
@@ -31,7 +31,11 @@ public class TokenService {
         return tokenFactory.createAccessToken(userId, role, Duration.ofDays(3));
     }
 
-    // todo : 검증 매커니즘 고민
+    public void deleteAllRefreshToken(Long userId) {
+        tokenRepository.deleteAllByUserId(userId);
+    }
+
+
     private Map<String, Object> validateRefreshToken(String refreshToken) {
         try {
             Jwt jwt = jwtDecoder.decode(refreshToken);

--- a/src/main/java/seondays/shareticon/login/token/TokenService.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenService.java
@@ -5,13 +5,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
-import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.jwt.JwtClaimsSet;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
-import org.springframework.security.oauth2.jwt.JwtEncoder;
-import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Service;
 import seondays.shareticon.login.UserRole;
@@ -20,19 +16,9 @@ import seondays.shareticon.login.UserRole;
 @RequiredArgsConstructor
 public class TokenService {
 
-    private final JwtEncoder jwtEncoder;
-    private final JwtDecoder jwtDecoder;
     private final TokenRepository tokenRepository;
-
-    public String createAccessToken(Long userId, UserRole role, Duration expiresIn) {
-        String jwt = createJwt(userId, role, TokenType.ACCESS, expiresIn);
-        return addBearerPrefix(jwt);
-    }
-
-    public RefreshToken createRefreshToken(Long userId, UserRole role, Duration expiresIn) {
-        String jwt = createJwt(userId, role, TokenType.REFRESH, expiresIn);
-        return RefreshToken.create(userId, jwt, expiresIn.getSeconds());
-    }
+    private final JwtDecoder jwtDecoder;
+    private final TokenFactory tokenFactory;
 
     public String reissueAccessToken(Cookie[] cookie) {
         String refreshToken = getRefreshToken(cookie);
@@ -42,7 +28,7 @@ public class TokenService {
         UserRole role = UserRole.getUserRoleBy((String) claims.get("role"));
         Long userId = (Long) claims.get("userId");
 
-        return createAccessToken(userId, role, Duration.ofDays(3));
+        return tokenFactory.createAccessToken(userId, role, Duration.ofDays(3));
     }
 
     // todo : 검증 매커니즘 고민
@@ -58,26 +44,11 @@ public class TokenService {
 
             return jwt.getClaims();
         } catch (JwtException e) {
-            throw new IllegalArgumentException("유효하지 않은 리프레시 토큰입니다.", e);
+            throw new BadCredentialsException("잘못된 리프레시 토큰입니다.");
         }
     }
 
-    private String createJwt(Long userId, UserRole role, TokenType tokenType, Duration expiresIn) {
-        Instant now = Instant.now();
-
-        JwsHeader header = JwsHeader.with(MacAlgorithm.HS256).type("JWT").build();
-        JwtClaimsSet claims = JwtClaimsSet.builder()
-                .issuedAt(now)
-                .expiresAt(now.plus(expiresIn))
-                .claim("userId", userId)
-                .claim("role", role)
-                .claim("tokenType", tokenType)
-                .build();
-
-        return jwtEncoder.encode(JwtEncoderParameters.from(header, claims)).getTokenValue();
-    }
-
-    private static String getRefreshToken(Cookie[] cookies) {
+    private String getRefreshToken(Cookie[] cookies) {
         String refresh = null;
         if (cookies != null) {
             for (Cookie cookie : cookies) {
@@ -90,33 +61,24 @@ public class TokenService {
         return refresh;
     }
 
-    // todo 예외 추가
     private void checkTokenType(Jwt jwt) {
         Map<String, Object> claims = jwt.getClaims();
         TokenType tokenType = TokenType.of((String) claims.get("tokenType"));
         if (!TokenType.isRefreshToken(tokenType)) {
-            throw new IllegalArgumentException("리프레시 토큰 타입이 아닙니다.");
+            throw new BadCredentialsException("리프레시 토큰 타입이 아닙니다.");
         }
     }
 
     private void checkExpiration(Jwt jwt) {
         Instant expiresAt = jwt.getExpiresAt();
         if (expiresAt.isBefore(Instant.now())) {
-            throw new IllegalArgumentException("리프레시 토큰이 만료되었습니다.");
+            throw new BadCredentialsException("리프레시 토큰이 만료되었습니다.");
         }
     }
 
     private void checkRefreshTokenSaved(String refreshToken) {
         if(!tokenRepository.existsById(refreshToken)) {
-            throw new IllegalArgumentException("리프레시 토큰이 만료되었습니다.");
+            throw new BadCredentialsException("리프레시 토큰이 만료되었습니다.");
         }
-    }
-
-    private String addBearerPrefix(String token) {
-        return "Bearer " + token;
-    }
-
-    private String detachBearerPrefix(String token) {
-        return token.split(" ")[1];
     }
 }

--- a/src/main/java/seondays/shareticon/login/token/TokenService.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenService.java
@@ -1,6 +1,7 @@
 package seondays.shareticon.login.token;
 
 import jakarta.servlet.http.Cookie;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
@@ -19,6 +20,7 @@ public class TokenService {
     private final TokenRepository tokenRepository;
     private final JwtDecoder jwtDecoder;
     private final TokenFactory tokenFactory;
+    private final Clock clock;
 
     public String reissueAccessToken(Cookie[] cookie) {
         String refreshToken = getRefreshToken(cookie);
@@ -78,7 +80,7 @@ public class TokenService {
 
     private void checkExpiration(Jwt jwt) {
         Instant expiresAt = jwt.getExpiresAt();
-        if (expiresAt.isBefore(Instant.now())) {
+        if (expiresAt.isBefore(clock.instant())) {
             throw new BadCredentialsException("리프레시 토큰이 만료되었습니다.");
         }
     }

--- a/src/test/java/seondays/shareticon/api/config/TestSecurityConfig.java
+++ b/src/test/java/seondays/shareticon/api/config/TestSecurityConfig.java
@@ -1,0 +1,23 @@
+package seondays.shareticon.api.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@TestConfiguration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(
+                auth -> auth.requestMatchers("/", "/reissue", "/error", "/oauth2**",
+                                "/swagger-ui/**", "/v3/api-docs/**", "/api-docs/**")
+                        .permitAll()
+                        .anyRequest().authenticated());
+
+        return http.build();
+    }
+}

--- a/src/test/java/seondays/shareticon/api/login/provider/OAuth2ProviderUserFactoryTest.java
+++ b/src/test/java/seondays/shareticon/api/login/provider/OAuth2ProviderUserFactoryTest.java
@@ -1,0 +1,52 @@
+package seondays.shareticon.api.login.provider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import seondays.shareticon.exception.IllegalOAuthProviderException;
+import seondays.shareticon.login.provider.KakaoUser;
+import seondays.shareticon.login.provider.OAuth2Provider;
+import seondays.shareticon.login.provider.OAuth2ProviderUserFactory;
+
+public class OAuth2ProviderUserFactoryTest {
+
+    private OAuth2ProviderUserFactory oAuth2ProviderUserFactory;
+
+    @BeforeEach
+    void setUp() {
+        oAuth2ProviderUserFactory = new OAuth2ProviderUserFactory();
+    }
+
+    @Test
+    @DisplayName("registrationId가 kakao면 kakao 유저가 생성된다")
+    void createUserWithKakao() {
+        //given
+        String registrationId = "kakao";
+        Map<String, Object> attributes = new HashMap<>();
+
+        //when
+        OAuth2Provider user = oAuth2ProviderUserFactory.getOAuth2User(registrationId,
+                attributes);
+
+        //then
+        assertThat(user).isInstanceOf(KakaoUser.class);
+    }
+
+    @Test
+    @DisplayName("해당되는 provider가 없으면 예외가 발생한다")
+    void createUserWithNoProvider() {
+        //given
+        String registrationId = "unknown";
+        Map<String, Object> attributes = new HashMap<>();
+
+        //when  //then
+        assertThatThrownBy(() ->
+                oAuth2ProviderUserFactory.getOAuth2User(registrationId, attributes)).isInstanceOf(
+                IllegalOAuthProviderException.class);
+    }
+}

--- a/src/test/java/seondays/shareticon/api/login/token/TokenControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/login/token/TokenControllerTest.java
@@ -1,0 +1,68 @@
+package seondays.shareticon.api.login.token;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import seondays.shareticon.api.config.TestSecurityConfig;
+import seondays.shareticon.login.token.TokenController;
+import seondays.shareticon.login.token.TokenService;
+
+@WebMvcTest(controllers = TokenController.class)
+@Import(TestSecurityConfig.class)
+public class TokenControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TokenService tokenService;
+
+    @Test
+    @DisplayName("리프레시 토큰으로 엑세스 토큰을 요청한다")
+    void reissueAccessToken() throws Exception {
+        //given
+        String accessToken = "Bearer expectedToken";
+
+        given(tokenService.reissueAccessToken(any(Cookie[].class))).willReturn(accessToken);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/reissue")
+                                .cookie(new Cookie("refresh", "refreshtoken"))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.header().string("Authorization", accessToken));
+    }
+
+    @Test
+    @DisplayName("엑세스 토큰 요청 시에는 리프레시 토큰이 있어야 한다")
+    void reissueAccessTokenWithNoRefreshToken() throws Exception {
+        // given
+        given(tokenService.reissueAccessToken(isNull()))
+                .willThrow(new BadCredentialsException("잘못된 리프레시 토큰입니다."));
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/reissue")
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized())
+                .andExpect(jsonPath("$.message").value("유효하지 않은 토큰입니다"))
+                .andExpect(jsonPath("$.code").value("401"));
+    }
+}

--- a/src/test/java/seondays/shareticon/api/login/token/TokenServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/login/token/TokenServiceTest.java
@@ -1,0 +1,116 @@
+package seondays.shareticon.api.login.token;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import jakarta.servlet.http.Cookie;
+import java.time.Duration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.test.context.ActiveProfiles;
+import seondays.shareticon.login.UserRole;
+import seondays.shareticon.login.token.RefreshToken;
+import seondays.shareticon.login.token.StoredRefreshToken;
+import seondays.shareticon.login.token.TokenFactory;
+import seondays.shareticon.login.token.TokenRepository;
+import seondays.shareticon.login.token.TokenService;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class TokenServiceTest {
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Autowired
+    private TokenFactory tokenFactory;
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Autowired
+    private RedisTemplate<String, StoredRefreshToken> redisTemplate;
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.getRequiredConnectionFactory()
+                .getConnection()
+                .serverCommands()
+                .flushDb();
+    }
+
+    @Test
+    @DisplayName("유효한 리프레시 토큰이 담긴 쿠키로 엑세스 토큰을 발급한다")
+    void createAccessTokenWithValidatedRefreshToken() {
+        //given
+        Long userId = 1L;
+        UserRole role = UserRole.ROLE_USER;
+        Duration duration = Duration.ofDays(1);
+        RefreshToken refreshToken = tokenFactory.createRefreshToken(userId, role, duration);
+        tokenRepository.save(refreshToken);
+
+        Cookie[] cookies = {new Cookie("refresh", refreshToken.getToken())};
+
+        //when
+        String accessToken = tokenService.reissueAccessToken(cookies);
+
+        //then
+        assertThat(accessToken).isNotNull();
+        assertThat(accessToken).startsWith("Bearer ");
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 이외의 토큰 타입으로 엑세스 토큰 발급 시 예외가 발생한다")
+    void createAccessTokenWithRefreshTokenType() {
+        //given
+        Long userId = 1L;
+        UserRole role = UserRole.ROLE_USER;
+        Duration duration = Duration.ofDays(1);
+        String NotRefreshToken = tokenFactory.createAccessToken(userId, role, duration);
+
+        Cookie[] cookies = {new Cookie("refresh", NotRefreshToken)};
+
+        //when //then
+        assertThatThrownBy(() -> tokenService.reissueAccessToken(cookies)).isInstanceOf(
+                BadCredentialsException.class);
+    }
+
+    @Test
+    @DisplayName("만료된 리프레시 토큰으로 액세스 토큰 발급 시 예외가 발생한다")
+    void createAccessTokenWithExpiredToken() throws InterruptedException {
+        //given
+        Long userId = 1L;
+        UserRole role = UserRole.ROLE_USER;
+        Duration duration = Duration.ofSeconds(1);
+        RefreshToken refreshToken = tokenFactory.createRefreshToken(userId, role, duration);
+
+        Cookie[] cookies = {new Cookie("refresh", refreshToken.getToken())};
+
+        //when //then
+        assertThatThrownBy(() -> tokenService.reissueAccessToken(cookies)).isInstanceOf(
+                BadCredentialsException.class);
+
+    }
+
+    @Test
+    @DisplayName("DB에 저장되어 있지 않은 리프레시 토큰으로 엑세스 토큰 발급 시 예외가 발생한다")
+    void createAccessTokenWithRefreshTokenNotSaved() {
+        //given
+        Long userId = 1L;
+        UserRole role = UserRole.ROLE_USER;
+        Duration duration = Duration.ofDays(1);
+        RefreshToken refreshToken = tokenFactory.createRefreshToken(userId, role, duration);
+
+        Cookie[] cookies = {new Cookie("refresh", refreshToken.getToken())};
+
+        //when //then
+        assertThatThrownBy(() -> tokenService.reissueAccessToken(cookies)).isInstanceOf(
+                BadCredentialsException.class);
+    }
+
+}

--- a/src/test/java/seondays/shareticon/api/user/UserRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/user/UserRepositoryTest.java
@@ -1,0 +1,39 @@
+package seondays.shareticon.api.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import seondays.shareticon.login.OAuth2Type;
+import seondays.shareticon.user.User;
+import seondays.shareticon.user.UserRepository;
+
+@ActiveProfiles("test")
+@DataJpaTest
+public class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+    
+    @Test
+    @DisplayName("oAuth2 id와 oAuth2 프로바이더 타입으로 유저를 조회한다")
+    void getUserWithoAuth2IdAndoAuth2Provider() {
+        //given
+        User user = User.builder().oauth2Id("1234").oauth2Type(OAuth2Type.KAKAO).build();
+        userRepository.save(user);
+
+        // when
+        Optional<User> result = userRepository.findByOauth2IdAndOauth2Type(
+                user.getOauth2Id(), user.getOauth2Type());
+
+        // then
+        assertThat(result).isPresent()
+                .get()
+                .extracting(User::getId, User::getOauth2Id, User::getOauth2Type)
+                .containsExactly(user.getId(), "1234", OAuth2Type.KAKAO);
+    }
+}

--- a/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
@@ -1,0 +1,47 @@
+package seondays.shareticon.api.userGroup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import seondays.shareticon.group.Group;
+import seondays.shareticon.group.GroupRepository;
+import seondays.shareticon.user.User;
+import seondays.shareticon.user.UserRepository;
+import seondays.shareticon.userGroup.UserGroup;
+import seondays.shareticon.userGroup.UserGroupRepository;
+
+@ActiveProfiles("test")
+@DataJpaTest
+public class UserGroupRepositoryTest {
+
+    @Autowired
+    private UserGroupRepository userGroupRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Test
+    @DisplayName("유저가 특정 그룹에 가입되어 있는지 조회한다")
+    void getUserWithGroup() {
+        //given
+        User user = User.builder().build();
+        Group group = Group.builder().build();
+        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
+        userRepository.save(user);
+        groupRepository.save(group);
+        userGroupRepository.save(userGroup);
+
+        //when
+        boolean result = userGroupRepository.existsByUserIdAndGroupId(user.getId(), group.getId());
+
+        //then
+        assertThat(result).isTrue();
+    }
+}

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
@@ -1,4 +1,4 @@
-package seondays.shareticon.voucher;
+package seondays.shareticon.api.voucher;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -22,6 +23,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.multipart.MultipartFile;
 import seondays.shareticon.login.CustomOAuth2User;
 import seondays.shareticon.user.dto.UserOAuth2Dto;
+import seondays.shareticon.voucher.VoucherController;
+import seondays.shareticon.voucher.VoucherService;
+import seondays.shareticon.voucher.VoucherStatus;
 import seondays.shareticon.voucher.dto.CreateVoucherRequest;
 import seondays.shareticon.voucher.dto.VouchersResponse;
 
@@ -30,6 +34,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
@@ -1,4 +1,4 @@
-package seondays.shareticon.voucher;
+package seondays.shareticon.api.voucher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,6 +14,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import seondays.shareticon.group.Group;
 import seondays.shareticon.group.GroupRepository;
+import seondays.shareticon.voucher.Voucher;
+import seondays.shareticon.voucher.VoucherRepository;
+import seondays.shareticon.voucher.VoucherStatus;
 
 @ActiveProfiles("test")
 @DataJpaTest

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -1,4 +1,4 @@
-package seondays.shareticon.voucher;
+package seondays.shareticon.api.voucher;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,6 +33,10 @@ import seondays.shareticon.user.User;
 import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.userGroup.UserGroup;
 import seondays.shareticon.userGroup.UserGroupRepository;
+import seondays.shareticon.voucher.Voucher;
+import seondays.shareticon.voucher.VoucherRepository;
+import seondays.shareticon.voucher.VoucherService;
+import seondays.shareticon.voucher.VoucherStatus;
 import seondays.shareticon.voucher.dto.CreateVoucherRequest;
 import seondays.shareticon.voucher.dto.VouchersResponse;
 

--- a/src/test/java/seondays/shareticon/docs/token/TokenControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/token/TokenControllerDocsTest.java
@@ -1,0 +1,59 @@
+package seondays.shareticon.docs.token;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
+import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import seondays.shareticon.docs.RestDocsSupport;
+import seondays.shareticon.login.token.TokenController;
+import seondays.shareticon.login.token.TokenService;
+
+public class TokenControllerDocsTest extends RestDocsSupport {
+
+    private final TokenService tokenService = mock(TokenService.class);
+
+    @Override
+    protected Object initController() {
+        return new TokenController(tokenService);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰으로 엑세스 토큰을 요청한다")
+    void reissueAccessToken() throws Exception {
+        //given
+        String accessToken = "Bearer expectedToken";
+
+        given(tokenService.reissueAccessToken(any(Cookie[].class))).willReturn(accessToken);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/reissue")
+                                .cookie(new Cookie("refresh", "refreshtoken"))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.header().string("Authorization", accessToken))
+                .andDo(document("token-reissue",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestCookies(cookieWithName("refresh").description("리프레시 토큰")),
+                        responseHeaders(
+                                headerWithName("Authorization").description("엑세스 토큰"))
+                        ));
+    }
+
+}


### PR DESCRIPTION
## 연관 이슈
#12 

## 작업 내용
1. 리프레시 토큰을 삭제하여 로그아웃하는 기능 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a logout endpoint to allow users to invalidate all refresh tokens.
  - Introduced a new component for creating JWT access and refresh tokens.
- **Bug Fixes**
  - Improved OAuth provider matching to be case-insensitive and use custom exceptions for unknown providers.
- **Documentation**
  - Added comprehensive API documentation for token issuance and reissue endpoints.
- **Refactor**
  - Centralized token creation logic and updated token management for better maintainability and extensibility.
  - Enhanced security configuration with explicit logout disablement and streamlined OAuth2 login setup.
- **Tests**
  - Added new unit and integration tests for token, user, group, and OAuth provider functionalities.
  - Enhanced API documentation tests for token endpoints.
- **Chores**
  - Updated package structures for test classes to improve organization.
  - Introduced a test-specific security configuration for controlled access during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->