### PR TITLE
Add to Logout API documentation and separate time setting objects

### DIFF
--- a/src/docs/asciidoc/api/token/token.adoc
+++ b/src/docs/asciidoc/api/token/token.adoc
@@ -10,3 +10,15 @@ include::{snippets}/token-reissue/request-cookies.adoc[]
 include::{snippets}/token-reissue/http-response.adoc[]
 ==== Response Header
 include::{snippets}/token-reissue/response-headers.adoc[]
+
+[[token-logout]]
+=== 로그아웃
+
+==== HTTP Request
+include::{snippets}/token-logout/http-request.adoc[]
+==== Request Header
+include::{snippets}/token-logout/request-headers.adoc[]
+
+==== HTTP Response
+include::{snippets}/token-logout/http-response.adoc[]
+

--- a/src/main/java/seondays/shareticon/config/JwtConfig.java
+++ b/src/main/java/seondays/shareticon/config/JwtConfig.java
@@ -2,6 +2,7 @@ package seondays.shareticon.config;
 
 import com.nimbusds.jose.jwk.source.ImmutableSecret;
 import java.nio.charset.StandardCharsets;
+import java.time.Clock;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,6 +10,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 
@@ -17,6 +19,11 @@ public class JwtConfig {
 
     @Value("${spring.jwt.secret}")
     private String jwtSecret;
+    private final Clock clock;
+
+    public JwtConfig(Clock clock) {
+        this.clock = clock;
+    }
 
     @Bean
     public JwtEncoder jwtEncoder() {
@@ -27,7 +34,13 @@ public class JwtConfig {
     @Bean
     public JwtDecoder jwtDecoder() {
         SecretKey secretKey = new SecretKeySpec(jwtSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
-        return NimbusJwtDecoder.withSecretKey(secretKey).build();
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withSecretKey(secretKey).build();
+
+        JwtTimestampValidator timestampValidator = new JwtTimestampValidator();
+        timestampValidator.setClock(clock);
+        decoder.setJwtValidator(timestampValidator);
+
+        return decoder;
     }
 
 }

--- a/src/main/java/seondays/shareticon/login/token/RefreshToken.java
+++ b/src/main/java/seondays/shareticon/login/token/RefreshToken.java
@@ -20,11 +20,11 @@ public class RefreshToken {
     private String expiration;
     private Long timeToLive;
 
-    public static RefreshToken create(Long id, String token, Long timeToLive) {
+    public static RefreshToken create(Long id, String token, Date expiration, Long timeToLive) {
         return RefreshToken.builder()
                 .userId(id)
                 .token(token)
-                .expiration(String.valueOf(Date.from(Instant.now().plusSeconds(timeToLive))))
+                .expiration(String.valueOf(expiration))
                 .timeToLive(timeToLive)
                 .build();
     }

--- a/src/main/java/seondays/shareticon/login/token/TokenFactory.java
+++ b/src/main/java/seondays/shareticon/login/token/TokenFactory.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.login.token;
 
+import java.sql.Date;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -26,7 +27,8 @@ public class TokenFactory {
 
     public RefreshToken createRefreshToken(Long userId, UserRole role, Duration expiresIn) {
         String jwt = createJwt(userId, role, TokenType.REFRESH, expiresIn);
-        return RefreshToken.create(userId, jwt, expiresIn.getSeconds());
+        Instant expirationInstant = clock.instant().plus(expiresIn);
+        return RefreshToken.create(userId, jwt, Date.from(expirationInstant), expiresIn.getSeconds());
     }
 
     private String createJwt(Long userId, UserRole role, TokenType tokenType, Duration expiresIn) {

--- a/src/test/java/seondays/shareticon/api/login/token/TokenRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/login/token/TokenRepositoryTest.java
@@ -39,8 +39,9 @@ public class TokenRepositoryTest extends RedisTestContainer {
         Long id = 1L;
         String token = "tokenvalue";
         Long ttl = 100L;
+        Date expiration = new Date();
 
-        RefreshToken refreshToken = RefreshToken.create(id, token, ttl);
+        RefreshToken refreshToken = RefreshToken.create(id, token, expiration,ttl);
 
         //when
         tokenRepository.save(refreshToken);
@@ -57,11 +58,12 @@ public class TokenRepositoryTest extends RedisTestContainer {
         String token1 = "token1";
         String token2 = "token2";
         String token3 = "token3";
+        Date expiration = new Date();
 
 
-        RefreshToken refreshToken1 = RefreshToken.create(userId, token1, 100L);
-        RefreshToken refreshToken2 = RefreshToken.create(userId, token2, 100L);
-        RefreshToken refreshToken3 = RefreshToken.create(userId, token3, 100L);
+        RefreshToken refreshToken1 = RefreshToken.create(userId, token1, expiration, 100L);
+        RefreshToken refreshToken2 = RefreshToken.create(userId, token2, expiration, 100L);
+        RefreshToken refreshToken3 = RefreshToken.create(userId, token3, expiration,100L);
         tokenRepository.save(refreshToken1);
         tokenRepository.save(refreshToken2);
         tokenRepository.save(refreshToken3);

--- a/src/test/java/seondays/shareticon/api/login/token/TokenRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/login/token/TokenRepositoryTest.java
@@ -2,6 +2,7 @@ package seondays.shareticon.api.login.token;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Date;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seondays/shareticon/api/login/token/TokenServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/login/token/TokenServiceTest.java
@@ -105,8 +105,9 @@ public class TokenServiceTest extends RedisTestContainer {
         UserRole role = UserRole.ROLE_USER;
         Duration duration = Duration.ofMinutes(10);
         RefreshToken refreshToken = tokenFactory.createRefreshToken(userId, role, duration);
+        tokenRepository.save(refreshToken);
 
-        Instant expiredTime = testSystemTimeInstant.plus(Duration.ofMinutes(1));
+        Instant expiredTime = testSystemTimeInstant.plus(Duration.ofMinutes(15));
         when(clock.instant()).thenReturn(expiredTime);
         Cookie[] cookies = {new Cookie("refresh", refreshToken.getToken())};
 

--- a/src/test/java/seondays/shareticon/docs/token/TokenControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/token/TokenControllerDocsTest.java
@@ -6,15 +6,19 @@ import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.cookies.CookieDocumentation.cookieWithName;
 import static org.springframework.restdocs.cookies.CookieDocumentation.requestCookies;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -53,6 +57,28 @@ public class TokenControllerDocsTest extends RestDocsSupport {
                         requestCookies(cookieWithName("refresh").description("리프레시 토큰")),
                         responseHeaders(
                                 headerWithName("Authorization").description("엑세스 토큰"))
+                        ));
+    }
+
+    @Test
+    @DisplayName("로그인 한 상태에서 로그아웃을 요청한다")
+    void requestLogoutWithAccessToken() throws Exception {
+        //given
+        String accessToken = "Bearer expectedToken";
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.post("/logout")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(document("token-logout",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestHeaders(headerWithName("Authorization").description("엑세스 토큰"))
                         ));
     }
 

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -128,6 +128,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
         mockMvc.perform(
                         MockMvcRequestBuilders.delete("/vouchers/group/{groupId}/voucher/{voucherId}",
                                         groupId, voucherId)
+                                .contentType(MediaType.APPLICATION_JSON)
                                 .with(authentication(auth))
                 )
                 .andDo(MockMvcResultHandlers.print())
@@ -241,6 +242,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
         mockMvc.perform(
                         MockMvcRequestBuilders.patch("/vouchers/group/{groupId}/voucher/{voucherId}",
                                         groupId, voucherId)
+                                .contentType(MediaType.APPLICATION_JSON)
                                 .with(authentication(auth))
                 )
                 .andDo(MockMvcResultHandlers.print())


### PR DESCRIPTION
## 연관 이슈
#12 

## 작업 내용
- 로그아웃 기능 문서 Spring REST Docs에 추가
- 테스트 코드 작성을 용이하게 하기 위해 시간을 세팅하는 기능을 외부에서 주입한 Clock 객체가 담당하도록 코드 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서화**
    - 토큰 API 문서에 로그아웃(Logout) 엔드포인트 관련 섹션이 추가되었습니다.

- **버그 수정**
    - 바우처 삭제 및 상태 변경 테스트에서 요청의 Content-Type을 명시적으로 application/json으로 설정했습니다.

- **테스트**
    - 로그아웃 API에 대한 테스트 및 문서화가 추가되었습니다.
    - 리프레시 토큰 생성 및 만료 테스트가 갱신된 만료 처리 로직을 반영하도록 수정되었습니다.

- **리팩터**
    - 토큰 만료 처리 및 리프레시 토큰 생성 방식이 명확한 만료 시각을 사용하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->