### PR TITLE
add group Test, Docs

### DIFF
--- a/src/docs/asciidoc/api/group/group.adoc
+++ b/src/docs/asciidoc/api/group/group.adoc
@@ -1,0 +1,31 @@
+[[group-create]]
+=== 그룹 생성
+==== HTTP Request
+include::{snippets}/group-create/http-request.adoc[]
+==== HTTP Response
+include::{snippets}/group-create/http-response.adoc[]
+include::{snippets}/group-create/response-fields.adoc[]
+==== Response Header
+include::{snippets}/group-create/response-headers.adoc[]
+
+=== 전체 그룹 조회
+==== HTTP Request
+include::{snippets}/group-get/http-request.adoc[]
+==== HTTP Response
+include::{snippets}/group-get/http-response.adoc[]
+include::{snippets}/group-get/response-fields.adoc[]
+
+=== 그룹 가입
+==== HTTP Request
+include::{snippets}/group-join/http-request.adoc[]
+include::{snippets}/group-join/request-fields.adoc[]
+==== HTTP Response
+include::{snippets}/group-join/http-response.adoc[]
+
+=== 그룹 가입 신청 내역 처리
+==== HTTP Request
+include::{snippets}/group-JoinList-approved/http-request.adoc[]
+include::{snippets}/group-JoinList-approved/path-parameters.adoc[]
+include::{snippets}/group-JoinList-approved/query-parameters.adoc[]
+==== HTTP Response
+include::{snippets}/group-JoinList-approved/http-response.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -19,3 +19,8 @@ include::api/voucher/voucher.adoc[]
 == Token API
 
 include::api/token/token.adoc[]
+
+[[Group-API]]
+== Group API
+
+include::api/group/group.adoc[]

--- a/src/main/java/seondays/shareticon/group/ApprovalStatus.java
+++ b/src/main/java/seondays/shareticon/group/ApprovalStatus.java
@@ -1,0 +1,10 @@
+package seondays.shareticon.group;
+
+public enum ApprovalStatus {
+    APPROVED,
+    REJECTED;
+
+    public static boolean isApproved(ApprovalStatus approvalStatus) {
+        return APPROVED.equals(approvalStatus);
+    }
+}

--- a/src/main/java/seondays/shareticon/group/Group.java
+++ b/src/main/java/seondays/shareticon/group/Group.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.group;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -29,5 +30,6 @@ public class Group {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "leader_user_id")
     private User leaderUser;
+    @Column(unique = true)
     private String inviteCode;
 }

--- a/src/main/java/seondays/shareticon/group/GroupController.java
+++ b/src/main/java/seondays/shareticon/group/GroupController.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.group;
 
+import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +43,7 @@ public class GroupController {
     }
 
     @PostMapping("/join")
-    public ResponseEntity<Void> applyToJoinGroup(@RequestBody ApplyToJoinRequest request,
+    public ResponseEntity<Void> applyToJoinGroup(@Valid @RequestBody ApplyToJoinRequest request,
             @AuthenticationPrincipal CustomOAuth2User userDetails) {
         Long userId = userDetails.getId();
         groupService.applyToJoinGroup(request, userId);

--- a/src/main/java/seondays/shareticon/group/GroupController.java
+++ b/src/main/java/seondays/shareticon/group/GroupController.java
@@ -51,7 +51,7 @@ public class GroupController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @GetMapping("/join-requests")
+    @GetMapping("/join")
     public ResponseEntity<List<ApplyToJoinResponse>> getAllApplyToJoinList(@AuthenticationPrincipal CustomOAuth2User userDetails) {
         Long userId = userDetails.getId();
         List<ApplyToJoinResponse> responseList = groupService.getAllApplyToJoinList(userId);

--- a/src/main/java/seondays/shareticon/group/GroupController.java
+++ b/src/main/java/seondays/shareticon/group/GroupController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import seondays.shareticon.group.dto.ApplyToJoinRequest;
 import seondays.shareticon.group.dto.ApplyToJoinResponse;
@@ -58,10 +59,13 @@ public class GroupController {
     }
 
     @PatchMapping("/{groupId}/user/{userId}")
-    public ResponseEntity<Void> acceptJoinApply(@AuthenticationPrincipal CustomOAuth2User userDetails,
-            @PathVariable("groupId") Long targetGroupId, @PathVariable("userId") Long targetUserId) {
+    public ResponseEntity<Void> changeJoinApplyStatus(
+            @AuthenticationPrincipal CustomOAuth2User userDetails,
+            @PathVariable("groupId") Long targetGroupId,
+            @PathVariable("userId") Long targetUserId,
+            @RequestParam("status") ApprovalStatus approvalStatus) {
         Long leaderId = userDetails.getId();
-        groupService.acceptJoinApply(targetGroupId, targetUserId, leaderId);
-        return new ResponseEntity<>(HttpStatus.OK);
+        groupService.changeJoinApplyStatus(targetGroupId, targetUserId, leaderId, approvalStatus);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/seondays/shareticon/group/GroupController.java
+++ b/src/main/java/seondays/shareticon/group/GroupController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import seondays.shareticon.group.dto.ApplyToJoinRequest;
 import seondays.shareticon.group.dto.ApplyToJoinResponse;
 import seondays.shareticon.group.dto.GroupListResponse;
+import seondays.shareticon.group.dto.GroupResponse;
 import seondays.shareticon.login.CustomOAuth2User;
 
 @RestController
@@ -28,11 +29,13 @@ public class GroupController {
     private final GroupService groupService;
 
     @PostMapping
-    public ResponseEntity<Void> createGroup(@AuthenticationPrincipal CustomOAuth2User userDetails) {
+    public ResponseEntity<GroupResponse> createGroup(
+            @AuthenticationPrincipal CustomOAuth2User userDetails) {
         Long userId = userDetails.getId();
-        Group createGroupId = groupService.createGroup(userId);
+        GroupResponse createdGroupResponse = groupService.createGroup(userId);
 
-        return ResponseEntity.created(URI.create("/group/" + createGroupId.getId())).build();
+        return ResponseEntity.created(URI.create("/group/" + createdGroupResponse.id()))
+                .body(createdGroupResponse);
     }
 
     @GetMapping
@@ -52,7 +55,8 @@ public class GroupController {
     }
 
     @GetMapping("/join")
-    public ResponseEntity<List<ApplyToJoinResponse>> getAllApplyToJoinList(@AuthenticationPrincipal CustomOAuth2User userDetails) {
+    public ResponseEntity<List<ApplyToJoinResponse>> getAllApplyToJoinList(
+            @AuthenticationPrincipal CustomOAuth2User userDetails) {
         Long userId = userDetails.getId();
         List<ApplyToJoinResponse> responseList = groupService.getAllApplyToJoinList(userId);
         return ResponseEntity.ok().body(responseList);

--- a/src/main/java/seondays/shareticon/group/GroupController.java
+++ b/src/main/java/seondays/shareticon/group/GroupController.java
@@ -1,6 +1,7 @@
 package seondays.shareticon.group;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import java.net.URI;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -67,7 +68,7 @@ public class GroupController {
             @AuthenticationPrincipal CustomOAuth2User userDetails,
             @PathVariable("groupId") Long targetGroupId,
             @PathVariable("userId") Long targetUserId,
-            @RequestParam("status") ApprovalStatus approvalStatus) {
+            @RequestParam("status") @NotNull ApprovalStatus approvalStatus) {
         Long leaderId = userDetails.getId();
         groupService.changeJoinApplyStatus(targetGroupId, targetUserId, leaderId, approvalStatus);
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/src/main/java/seondays/shareticon/group/GroupController.java
+++ b/src/main/java/seondays/shareticon/group/GroupController.java
@@ -51,7 +51,7 @@ public class GroupController {
             @AuthenticationPrincipal CustomOAuth2User userDetails) {
         Long userId = userDetails.getId();
         groupService.applyToJoinGroup(request, userId);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @GetMapping("/join")
@@ -70,6 +70,6 @@ public class GroupController {
             @RequestParam("status") ApprovalStatus approvalStatus) {
         Long leaderId = userDetails.getId();
         groupService.changeJoinApplyStatus(targetGroupId, targetUserId, leaderId, approvalStatus);
-        return ResponseEntity.ok().build();
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/seondays/shareticon/group/GroupRepository.java
+++ b/src/main/java/seondays/shareticon/group/GroupRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
     Optional<Group> findByInviteCode(String inviteCode);
+
+    boolean existsByInviteCode(String inviteCode);
 }

--- a/src/main/java/seondays/shareticon/group/GroupService.java
+++ b/src/main/java/seondays/shareticon/group/GroupService.java
@@ -111,11 +111,11 @@ public class GroupService {
         userGroupRepository.save(userGroup);
     }
 
-    public List<ApplyToJoinResponse> getAllApplyToJoinList(Long userId) {
-        User user = userRepository.findById(userId)
+    public List<ApplyToJoinResponse> getAllApplyToJoinList(Long leaderUserId) {
+        User leaderUser = userRepository.findById(leaderUserId)
                 .orElseThrow(UserNotFoundException::new);
 
-        return userGroupRepository.findPendingByLeader(userId, PENDING)
+        return userGroupRepository.findPendingByLeader(leaderUser.getId(), PENDING)
                 .stream()
                 .map(ApplyToJoinResponse::of)
                 .toList();

--- a/src/main/java/seondays/shareticon/group/GroupService.java
+++ b/src/main/java/seondays/shareticon/group/GroupService.java
@@ -127,8 +127,9 @@ public class GroupService {
         Group targetGroup = groupRepository.findById(targetGroupId)
                 .orElseThrow(GroupNotFoundException::new);
 
-        User targetUser = userRepository.findById(targetUserId)
-                .orElseThrow(UserNotFoundException::new);
+        if (!userRepository.existsById(targetUserId)) {
+            throw new UserNotFoundException();
+        }
 
         validateLeader(leaderId, targetGroup);
 

--- a/src/main/java/seondays/shareticon/group/GroupService.java
+++ b/src/main/java/seondays/shareticon/group/GroupService.java
@@ -21,6 +21,7 @@ import seondays.shareticon.exception.UserNotFoundException;
 import seondays.shareticon.group.dto.ApplyToJoinRequest;
 import seondays.shareticon.group.dto.ApplyToJoinResponse;
 import seondays.shareticon.group.dto.GroupListResponse;
+import seondays.shareticon.group.dto.GroupResponse;
 import seondays.shareticon.user.User;
 import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.userGroup.UserGroup;
@@ -38,7 +39,7 @@ public class GroupService {
     private final RandomCodeFactory randomCodeFactory;
 
     @Transactional
-    public Group createGroup(Long userId) {
+    public GroupResponse createGroup(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
         int maxRetry = 3;
@@ -67,7 +68,7 @@ public class GroupService {
                     .joinStatus(JoinStatus.JOINED)
                     .build());
 
-            return newGroup;
+            return GroupResponse.of(newGroup);
         }
         throw new GroupCreateException();
     }

--- a/src/main/java/seondays/shareticon/group/RandomCodeFactory.java
+++ b/src/main/java/seondays/shareticon/group/RandomCodeFactory.java
@@ -1,0 +1,20 @@
+package seondays.shareticon.group;
+
+import java.security.SecureRandom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RandomCodeFactory {
+
+    private final SecureRandom secureRandom = new SecureRandom();
+    private static final String CHARSET = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+    private static final int CODE_LENGTH = 10;
+
+    public String createInviteCode() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < CODE_LENGTH; i++) {
+            sb.append(CHARSET.charAt(secureRandom.nextInt(CHARSET.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/seondays/shareticon/group/dto/ApplyToJoinRequest.java
+++ b/src/main/java/seondays/shareticon/group/dto/ApplyToJoinRequest.java
@@ -1,5 +1,7 @@
 package seondays.shareticon.group.dto;
 
-public record ApplyToJoinRequest(String inviteCode) {
+import jakarta.validation.constraints.NotEmpty;
+
+public record ApplyToJoinRequest(@NotEmpty String inviteCode) {
 
 }

--- a/src/main/java/seondays/shareticon/group/dto/GroupResponse.java
+++ b/src/main/java/seondays/shareticon/group/dto/GroupResponse.java
@@ -1,0 +1,11 @@
+package seondays.shareticon.group.dto;
+
+import seondays.shareticon.group.Group;
+
+public record GroupResponse(Long id,
+                            String inviteCode) {
+
+    public static GroupResponse of(Group group) {
+        return new GroupResponse(group.getId(), group.getInviteCode());
+    }
+}

--- a/src/main/java/seondays/shareticon/user/UserRepository.java
+++ b/src/main/java/seondays/shareticon/user/UserRepository.java
@@ -8,4 +8,6 @@ import seondays.shareticon.login.OAuth2Type;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByOauth2IdAndOauth2Type(String oauth2Id, OAuth2Type oauth2Type);
+
+    boolean existsById(Long userId);
 }

--- a/src/main/java/seondays/shareticon/voucher/VoucherController.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherController.java
@@ -2,6 +2,7 @@ package seondays.shareticon.voucher;
 
 import jakarta.validation.Valid;
 import java.net.URI;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -22,14 +23,11 @@ import seondays.shareticon.voucher.dto.CreateVoucherRequest;
 import seondays.shareticon.voucher.dto.VouchersResponse;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/vouchers")
 public class VoucherController {
 
     private final VoucherService voucherService;
-
-    public VoucherController(VoucherService voucherService) {
-        this.voucherService = voucherService;
-    }
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<VouchersResponse> registerVoucher(

--- a/src/test/java/seondays/shareticon/api/group/GroupControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupControllerTest.java
@@ -1,0 +1,226 @@
+package seondays.shareticon.api.group;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import seondays.shareticon.group.Group;
+import seondays.shareticon.group.GroupController;
+import seondays.shareticon.group.GroupService;
+import seondays.shareticon.group.dto.ApplyToJoinRequest;
+import seondays.shareticon.group.dto.ApplyToJoinResponse;
+import seondays.shareticon.group.dto.GroupListResponse;
+import seondays.shareticon.group.dto.GroupResponse;
+import seondays.shareticon.login.CustomOAuth2User;
+import seondays.shareticon.user.dto.UserOAuth2Dto;
+
+@WebMvcTest(controllers = GroupController.class)
+public class GroupControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    private CustomOAuth2User mockUser;
+
+    @MockitoBean
+    private GroupService groupService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setup() {
+        mockUser = new CustomOAuth2User(new UserOAuth2Dto(1L, "user", "ROLE_USER"));
+    }
+
+    @Test
+    @DisplayName("그룹을 새로 생성한다")
+    void createGroupTest() throws Exception {
+        //given
+        Group createdGroup = Group.builder()
+                .id(1L)
+                .build();
+
+        when(groupService.createGroup(any(Long.class))).thenReturn(GroupResponse.of(createdGroup));
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.post("/group")
+                                .with(csrf())
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(header().string("Location", "/group/1"));
+    }
+
+    @Test
+    @DisplayName("유저의 모든 그룹 리스트를 조회한다")
+    void getAllGroupList() throws Exception {
+        //given
+        GroupListResponse response1 = new GroupListResponse(1L);
+        GroupListResponse response2 = new GroupListResponse(2L);
+        List<GroupListResponse> responseList = List.of(response1, response2);
+
+        when(groupService.getAllGroupList(any(Long.class))).thenReturn(responseList);
+
+        //when //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/group")
+                        .with(csrf())
+                        .with(oauth2Login().oauth2User(mockUser))
+        )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("그룹 가입을 신청한다")
+    void applyToJoinGroup() throws Exception {
+        //given
+        ApplyToJoinRequest request = new ApplyToJoinRequest("inviteCode");
+        String json = new ObjectMapper().writeValueAsString(request);
+
+        //when //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.post("/group/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json)
+                        .with(csrf())
+                        .with(oauth2Login().oauth2User(mockUser))
+        )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("그룹 가입 신청 시 대상 그룹Id는 필수이다")
+    void applyToJoinGroupWithoutGroupId() throws Exception {
+        //given
+        ApplyToJoinRequest request = new ApplyToJoinRequest("");
+        String json = new ObjectMapper().writeValueAsString(request);
+
+        //when //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.post("/group/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json)
+                        .with(csrf())
+                        .with(oauth2Login().oauth2User(mockUser))
+        )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("유저가 확인할 수 있는 가입 신청 리스트를 조회한다")
+    void getAllApplyToJoinList() throws Exception {
+        //given
+        Long userId = mockUser.getId();
+        String userName = mockUser.getName();
+        ApplyToJoinResponse response1 = new ApplyToJoinResponse(userId, userName, 1L);
+        ApplyToJoinResponse response2 = new ApplyToJoinResponse(userId, userName, 2L);
+        List<ApplyToJoinResponse> responseList = List.of(response1, response2);
+
+        when(groupService.getAllApplyToJoinList(any(Long.class))).thenReturn(responseList);
+
+        //when //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/group/join")
+                        .with(csrf())
+                        .with(oauth2Login().oauth2User(mockUser))
+        )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("가입 신청 내역을 승인한다")
+    void approvedJoinApplyStatus() throws Exception {
+        //given
+        Long userId = mockUser.getId();
+
+        //when //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.patch("/group/{groupId}/user/{userId}", 1L, userId)
+                        .param("status", "APPROVED")
+                        .with(csrf())
+                        .with(oauth2Login().oauth2User(mockUser))
+        )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("가입 신청 내역을 거절한다")
+    void rejectJoinApplyStatus() throws Exception {
+        //given
+        Long userId = mockUser.getId();
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.patch("/group/{groupId}/user/{userId}", 1L, userId)
+                                .param("status", "REJECTED")
+                                .with(csrf())
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    @DisplayName("가입 신청 상태 변경 시, groupId는 Long 타입이어야 한다")
+    void joinApplyStatusWithoutGroupIdLongType() throws Exception {
+        //given
+        Long userId = mockUser.getId();
+        String groupId = "groupId";
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.patch("/group/{groupId}/user/{userId}", groupId, userId)
+                                .param("status", "REJECTED")
+                                .with(csrf())
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("가입 신청 상태 변경 시, userId는 Long 타입이어야 한다")
+    void joinApplyStatusWithoutUserIdLongType() throws Exception {
+        //given
+        String userId = "1L";
+        Long groupId = 1L;
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.patch("/group/{groupId}/user/{userId}", groupId, userId)
+                                .param("status", "REJECTED")
+                                .with(csrf())
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isBadRequest());
+    }
+}

--- a/src/test/java/seondays/shareticon/api/group/GroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupRepositoryTest.java
@@ -1,0 +1,87 @@
+package seondays.shareticon.api.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import seondays.shareticon.group.Group;
+import seondays.shareticon.group.GroupRepository;
+
+@ActiveProfiles("test")
+@DataJpaTest
+public class GroupRepositoryTest {
+
+    @Autowired
+    private GroupRepository groupRepository;
+    
+    @Test
+    @DisplayName("특정 초대 코드를 가진 그룹을 조회한다")
+    void findByInviteCode() {
+        //given
+        String inviteCode = "ABC";
+        Group group = Group.builder().inviteCode(inviteCode).build();
+        groupRepository.save(group);
+
+        //when
+        Optional<Group> result = groupRepository.findByInviteCode(group.getInviteCode());
+
+        //then
+        assertThat(result).isNotEmpty();
+        assertThat(result.get().getInviteCode()).isEqualTo(inviteCode);
+
+    }
+
+    @Test
+    @DisplayName("특정 초대 코드를 가진 그룹이 없는 경우 빈 optional을 조회한다")
+    void findByNoExistInviteCode() {
+        //given
+        String inviteCode = "ABC";
+        Group group = Group.builder().inviteCode(inviteCode).build();
+        groupRepository.save(group);
+
+        //when
+        String testInviteCode = "test";
+        Optional<Group> result = groupRepository.findByInviteCode(testInviteCode);
+
+        //then
+        assertThat(result).isEmpty();
+
+    }
+
+    @Test
+    @DisplayName("특정 초대 코드를 가진 그룹이 존재하는 경우 true가 반환된다")
+    void existByInviteCode() {
+        //given
+        String inviteCode = "ABC";
+        Group group = Group.builder().inviteCode(inviteCode).build();
+        groupRepository.save(group);
+
+        //when
+        boolean result = groupRepository.existsByInviteCode(inviteCode);
+
+        //then
+        assertThat(result).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("특정 초대 코드를 가진 그룹이 존재하지 않는 경오 false가 반환된다")
+    void noExistByInviteCode() {
+        //given
+        String inviteCode = "ABC";
+        Group group = Group.builder().inviteCode(inviteCode).build();
+        groupRepository.save(group);
+
+        //when
+        String testInviteCode = "test";
+        boolean result = groupRepository.existsByInviteCode(testInviteCode);
+
+        //then
+        assertThat(result).isFalse();
+
+    }
+}

--- a/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
@@ -1,0 +1,555 @@
+package seondays.shareticon.api.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.doReturn;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Transactional;
+import seondays.shareticon.exception.AlreadyAppliedToGroupException;
+import seondays.shareticon.exception.GroupCreateException;
+import seondays.shareticon.exception.GroupNotFoundException;
+import seondays.shareticon.exception.InvalidAcceptGroupJoinApplyException;
+import seondays.shareticon.exception.InvalidJoinGroupException;
+import seondays.shareticon.exception.UserNotFoundException;
+import seondays.shareticon.group.ApprovalStatus;
+import seondays.shareticon.group.Group;
+import seondays.shareticon.group.GroupRepository;
+import seondays.shareticon.group.GroupService;
+import seondays.shareticon.group.JoinStatus;
+import seondays.shareticon.group.RandomCodeFactory;
+import seondays.shareticon.group.dto.ApplyToJoinRequest;
+import seondays.shareticon.group.dto.ApplyToJoinResponse;
+import seondays.shareticon.group.dto.GroupListResponse;
+import seondays.shareticon.group.dto.GroupResponse;
+import seondays.shareticon.user.User;
+import seondays.shareticon.user.UserRepository;
+import seondays.shareticon.userGroup.UserGroup;
+import seondays.shareticon.userGroup.UserGroupRepository;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest
+public class GroupServiceTest {
+
+    @Autowired
+    private GroupService groupService;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserGroupRepository userGroupRepository;
+
+    @MockitoSpyBean
+    private RandomCodeFactory randomCodeFactory;
+
+    @Test
+    @DisplayName("그룹을 생성한다")
+    void createGroup() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        //when
+        GroupResponse groupResponse = groupService.createGroup(user.getId());
+
+        //then
+        assertThat(groupResponse).isNotNull();
+    }
+
+    @Test
+    @DisplayName("그룹을 생성하는 유저는 DB에 저장된 회원이어야 한다")
+    void createGroupWithoutExistUser() {
+        //given
+        User user = User.builder().id(1L).build();
+
+        //when //then
+        assertThatThrownBy(() -> groupService.createGroup(user.getId())).isInstanceOf(
+                UserNotFoundException.class);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideInviteCodeScenarios")
+    @DisplayName("그룹 코드 중복 시 재시도 및 예외 발생 시나리오를 테스트한다")
+    void createGroupWithRetry(String displayName, List<String> inviteCodes, String expectedCode,
+            boolean expectException) {
+        //given
+        User user = userRepository.save(User.builder().build());
+        groupRepository.save(Group.builder().leaderUser(user).inviteCode("AAAAAAAA").build());
+
+        doReturn(inviteCodes.get(0), inviteCodes.get(1), inviteCodes.get(2))
+                .when(randomCodeFactory).createInviteCode();
+
+        //when //then
+        if (expectException) {
+            assertThatThrownBy(() -> groupService.createGroup(user.getId()))
+                    .isInstanceOf(GroupCreateException.class);
+        } else {
+            GroupResponse groupResponse = groupService.createGroup(user.getId());
+            assertThat(groupResponse.inviteCode()).isEqualTo(expectedCode);
+        }
+    }
+
+    static Stream<Arguments> provideInviteCodeScenarios() {
+        return Stream.of(
+                Arguments.of("그룹 코드가 중복이 되어 그룹 생성이 실패하는 경우 최대 3회까지 재시도한다",
+                        List.of("AAAAAAAA", "AAAAAAAA", "BBBBBBBB"),
+                        "BBBBBBBB",
+                        false),
+                Arguments.of("그룹 코드가 중복되어 그룹 생성이 3회 이상 실패하는 경우에는 예외가 발생한다",
+                        List.of("AAAAAAAA", "AAAAAAAA", "AAAAAAAA"),
+                        null,
+                        true)
+        );
+    }
+
+    @Test
+    @DisplayName("해당 유저의 전체 그룹 리스트를 조회한다")
+    void getAllGroupList() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        Group group1 = Group.builder().build();
+        Group group2 = Group.builder().build();
+        groupRepository.saveAll(List.of(group1, group2));
+
+        UserGroup userGroup1 = UserGroup.builder().user(user).group(group1).build();
+        UserGroup userGroup2 = UserGroup.builder().user(user).group(group2).build();
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+
+        //when
+        List<GroupListResponse> responseList = groupService.getAllGroupList(user.getId());
+
+        //then
+        assertThat(responseList).hasSize(2);
+        assertThat(responseList).extracting("groupId")
+                .contains(group1.getId(), group2.getId());
+    }
+
+    @Test
+    @DisplayName("유저가 가입된 그룹이 없다면, 해당 유저의 전체 그룹 리스트를 조회 시 빈 리스트가 조회된다")
+    void getAllGroupListWhenNoGroupJoin() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        //when
+        List<GroupListResponse> responseList = groupService.getAllGroupList(user.getId());
+
+        //then
+        assertThat(responseList).isEmpty();
+    }
+
+    @Test
+    @DisplayName("유효한 그룹 코드를 가지고 가입을 신청한다")
+    void applyToJoinGroup() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        Group group = Group.builder().inviteCode("ok").build();
+        groupRepository.save(group);
+
+        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+
+        //when
+        groupService.applyToJoinGroup(request, user.getId());
+
+        //then
+        Optional<UserGroup> result = userGroupRepository.findByUserIdAndGroupId(
+                user.getId(), group.getId());
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.get().getJoinStatus()).isEqualTo(JoinStatus.PENDING);
+        assertThat(result.get().getGroup().getInviteCode()).isEqualTo("ok");
+        assertThat(result.get().getGroup().getId()).isEqualTo(group.getId());
+        assertThat(result.get().getUser().getId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    @DisplayName("그룹 가입을 신청하는 유저는 DB에 저장된 회원이어야 한다")
+    void applyToJoinGroupWithoutExistUser() {
+        //given
+        User user = User.builder().id(1L).build();
+
+        Group group = Group.builder().inviteCode("ok").build();
+        groupRepository.save(group);
+
+        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+
+        //when //then
+        assertThatThrownBy(() -> groupService.applyToJoinGroup(request, user.getId()))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("가입을 신청하는 그룹은 존재하는 그룹이어야 한다")
+    void applyToJoinGroupWithoutExistGroup() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+
+        //when //then
+        assertThatThrownBy(() -> groupService.applyToJoinGroup(request, user.getId()))
+                .isInstanceOf(GroupNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("이미 가입 신청한 그룹에 다시 신청할 수는 없다")
+    void applyToJoinGroupAlreadyPending() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        Group group = Group.builder().inviteCode("ok").build();
+        groupRepository.save(group);
+
+        JoinStatus status = JoinStatus.PENDING;
+        UserGroup userGroup = UserGroup.builder().user(user).group(group).joinStatus(status)
+                .build();
+        userGroupRepository.save(userGroup);
+
+        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+
+        //when //then
+        assertThatThrownBy(() -> groupService.applyToJoinGroup(request, user.getId()))
+                .isInstanceOf(AlreadyAppliedToGroupException.class);
+    }
+
+    @Test
+    @DisplayName("이미 가입된 그룹에 다시 신청할 수는 없다")
+    void applyToJoinGroupAlreadyJoined() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        Group group = Group.builder().inviteCode("ok").build();
+        groupRepository.save(group);
+
+        JoinStatus status = JoinStatus.JOINED;
+        UserGroup userGroup = UserGroup.builder().user(user).group(group).joinStatus(status)
+                .build();
+        userGroupRepository.save(userGroup);
+
+        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+
+        //when //then
+        assertThatThrownBy(() -> groupService.applyToJoinGroup(request, user.getId()))
+                .isInstanceOf(AlreadyAppliedToGroupException.class);
+    }
+
+    @Test
+    @DisplayName("거절된 상태에서는 다시 가입 신청이 가능하다")
+    void applyToJoinGroupStatusRejected() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        Group group = Group.builder().inviteCode("ok").build();
+        groupRepository.save(group);
+
+        JoinStatus status = JoinStatus.REJECTED;
+        UserGroup userGroup = UserGroup.builder().user(user).group(group).joinStatus(status)
+                .build();
+        userGroupRepository.save(userGroup);
+
+        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+
+        //when
+        groupService.applyToJoinGroup(request, user.getId());
+
+        //then
+        Optional<UserGroup> result = userGroupRepository.findByUserIdAndGroupId(
+                user.getId(), group.getId());
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.get().getJoinStatus()).isEqualTo(JoinStatus.PENDING);
+        assertThat(result.get().getGroup().getInviteCode()).isEqualTo("ok");
+        assertThat(result.get().getGroup().getId()).isEqualTo(group.getId());
+        assertThat(result.get().getUser().getId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    @DisplayName("리더에게 들어온 그룹 신청 내역 목록을 조회한다")
+    void getAllApplyToJoinList() {
+        //given
+        User leaderUser = User.builder().build();
+        User pendingUser = User.builder().build();
+        userRepository.save(leaderUser);
+        userRepository.save(pendingUser);
+
+        Group group = Group.builder().leaderUser(leaderUser).build();
+        groupRepository.save(group);
+
+        UserGroup userGroup1 = UserGroup.builder().user(leaderUser).group(group)
+                .joinStatus(JoinStatus.JOINED).build();
+        UserGroup userGroup2 = UserGroup.builder().user(pendingUser).group(group)
+                .joinStatus(JoinStatus.PENDING).build();
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+
+        //when
+        List<ApplyToJoinResponse> result = groupService.getAllApplyToJoinList(
+                leaderUser.getId());
+
+        //then
+        assertThat(result).hasSize(1)
+                .extracting("applyUserId", "targetGroupId")
+                .contains(tuple(pendingUser.getId(), group.getId()));
+    }
+
+    @Test
+    @DisplayName("리더를 맡고 있는 그룹이 없다면, 그룹 신청 내역 목록을 조회 시 빈 리스트가 조회된다")
+    void getAllApplyToJoinListWithNoLeaderUser() {
+        //given
+        User leaderUser = User.builder().build();
+        User pendingUser = User.builder().build();
+        userRepository.save(leaderUser);
+        userRepository.save(pendingUser);
+
+        Group group = Group.builder().build();
+        groupRepository.save(group);
+
+        UserGroup userGroup1 = UserGroup.builder().user(leaderUser).group(group)
+                .joinStatus(JoinStatus.JOINED).build();
+        UserGroup userGroup2 = UserGroup.builder().user(pendingUser).group(group)
+                .joinStatus(JoinStatus.PENDING).build();
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+
+        //when
+        List<ApplyToJoinResponse> result = groupService.getAllApplyToJoinList(
+                leaderUser.getId());
+
+        //then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("그룹 신청 내역을 조회하는 유저는 DB에 저장된 회원이어야 한다")
+    void getAllApplyToJoinListWithoutExistUser() {
+        //given
+        User user = User.builder().id(1L).build();
+
+        //when //then
+        assertThatThrownBy(() -> groupService.getAllApplyToJoinList(user.getId()))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("그룹 가입 신청을 승낙한다")
+    void changeJoinApplyStatusApproved() {
+        //given
+        User leaderUser = User.builder().build();
+        User pendingUser = User.builder().build();
+        userRepository.save(leaderUser);
+        userRepository.save(pendingUser);
+
+        Group group = Group.builder().leaderUser(leaderUser).build();
+        groupRepository.save(group);
+
+        UserGroup userGroup1 = UserGroup.builder().user(leaderUser).group(group)
+                .joinStatus(JoinStatus.JOINED).build();
+        UserGroup userGroup2 = UserGroup.builder().user(pendingUser).group(group)
+                .joinStatus(JoinStatus.PENDING).build();
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+
+        //when
+        ApprovalStatus leaderDecision = ApprovalStatus.APPROVED;
+        groupService.changeJoinApplyStatus(group.getId(), pendingUser.getId(), leaderUser.getId(),
+                leaderDecision);
+
+        //then
+        Optional<UserGroup> result = userGroupRepository.findByUserIdAndGroupId(
+                pendingUser.getId(), group.getId());
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.get().getJoinStatus()).isEqualTo(JoinStatus.JOINED);
+        assertThat(result.get().getUser()).isEqualTo(pendingUser);
+    }
+
+    @Test
+    @DisplayName("그룹 가입 신청을 거절한다")
+    void changeJoinApplyStatusRejected() {
+        //given
+        User leaderUser = User.builder().build();
+        User pendingUser = User.builder().build();
+        userRepository.save(leaderUser);
+        userRepository.save(pendingUser);
+
+        Group group = Group.builder().leaderUser(leaderUser).build();
+        groupRepository.save(group);
+
+        UserGroup userGroup1 = UserGroup.builder().user(leaderUser).group(group)
+                .joinStatus(JoinStatus.JOINED).build();
+        UserGroup userGroup2 = UserGroup.builder().user(pendingUser).group(group)
+                .joinStatus(JoinStatus.PENDING).build();
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+
+        //when
+        ApprovalStatus leaderDecision = ApprovalStatus.REJECTED;
+        groupService.changeJoinApplyStatus(group.getId(), pendingUser.getId(), leaderUser.getId(),
+                leaderDecision);
+
+        //then
+        Optional<UserGroup> result = userGroupRepository.findByUserIdAndGroupId(
+                pendingUser.getId(), group.getId());
+
+        assertThat(result).isNotEmpty();
+        assertThat(result.get().getJoinStatus()).isEqualTo(JoinStatus.REJECTED);
+        assertThat(result.get().getUser()).isEqualTo(pendingUser);
+    }
+
+    @Test
+    @DisplayName("그룹 가입 신청 여부 처리 시, 가입 대기중이 아닌 유저는 처리 대상이 아니다")
+    void changeJoinApplyWithoutPendingUser() {
+        //given
+        User leaderUser = User.builder().build();
+        User joinedUser = User.builder().build();
+        userRepository.save(leaderUser);
+        userRepository.save(joinedUser);
+
+        Group group = Group.builder().leaderUser(leaderUser).build();
+        groupRepository.save(group);
+
+        UserGroup userGroup1 = UserGroup.builder().user(leaderUser).group(group)
+                .joinStatus(JoinStatus.JOINED).build();
+        UserGroup userGroup2 = UserGroup.builder().user(joinedUser).group(group)
+                .joinStatus(JoinStatus.JOINED).build();
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+
+        //when //then
+        ApprovalStatus leaderDecision = ApprovalStatus.APPROVED;
+        assertThatThrownBy(
+                () -> groupService.changeJoinApplyStatus(group.getId(), joinedUser.getId(),
+                        leaderUser.getId(), leaderDecision))
+                .isInstanceOf(InvalidJoinGroupException.class);
+    }
+
+    @Test
+    @DisplayName("그룹 가입 신청 여부 처리 시, 존재하는 그룹에 관련된 요청을 처리해야 한다")
+    void changeJoinApplyWithoutExistGroup() {
+        //given
+        User leaderUser = User.builder().build();
+        User pendingUser = User.builder().build();
+        userRepository.save(leaderUser);
+        userRepository.save(pendingUser);
+
+        Group group = Group.builder().id(1L).leaderUser(leaderUser).build();
+
+        //when //then
+        ApprovalStatus leaderDecision = ApprovalStatus.APPROVED;
+        assertThatThrownBy(
+                () -> groupService.changeJoinApplyStatus(group.getId(), pendingUser.getId(),
+                        leaderUser.getId(), leaderDecision))
+                .isInstanceOf(GroupNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("그룹 가입 신청 여부를 결정하는 유저는 그룹 리더여야 한다")
+    void changeJoinApplyWithoutGroupLeader() {
+        //given
+        User notLeaderUser = User.builder().build();
+        User leaderUser = User.builder().build();
+        User pendingUser = User.builder().build();
+        userRepository.save(notLeaderUser);
+        userRepository.save(leaderUser);
+        userRepository.save(pendingUser);
+
+        Group group = Group.builder().leaderUser(leaderUser).build();
+        groupRepository.save(group);
+
+        UserGroup userGroup1 = UserGroup.builder().user(notLeaderUser).group(group)
+                .joinStatus(JoinStatus.JOINED).build();
+        UserGroup userGroup2 = UserGroup.builder().user(pendingUser).group(group)
+                .joinStatus(JoinStatus.PENDING).build();
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+
+        //when //then
+        ApprovalStatus leaderDecision = ApprovalStatus.APPROVED;
+        assertThatThrownBy(
+                () -> groupService.changeJoinApplyStatus(group.getId(), pendingUser.getId(),
+                        notLeaderUser.getId(), leaderDecision))
+                .isInstanceOf(InvalidAcceptGroupJoinApplyException.class);
+    }
+
+    @Test
+    @DisplayName("그룹 가입 신청 여부를 결정하는 리더 유저는 DB에 저장된 회원이어야 한다")
+    void changeJoinApplyWithoutExistLeaderUser() {
+        //given
+        User leaderUser = User.builder().id(123L).build();
+        User pendingUser = User.builder().build();
+        userRepository.save(pendingUser);
+
+        Group group = Group.builder().build();
+        groupRepository.save(group);
+
+        //when //then
+        ApprovalStatus leaderDecision = ApprovalStatus.APPROVED;
+        assertThatThrownBy(
+                () -> groupService.changeJoinApplyStatus(group.getId(), pendingUser.getId(),
+                        leaderUser.getId(), leaderDecision))
+                .isInstanceOf(InvalidAcceptGroupJoinApplyException.class);
+    }
+
+    @Test
+    @DisplayName("그룹 가입 신청 여부를 결정하는 리더는 해당 그룹에 속해있어야 한다")
+    void chaneJoinApplyWithoutJoinedLeader() {
+        //given
+        User leaderUser = User.builder().build();
+        User pendingUser = User.builder().build();
+        userRepository.save(leaderUser);
+        userRepository.save(pendingUser);
+
+        Group group = Group.builder().leaderUser(leaderUser).build();
+        groupRepository.save(group);
+
+        UserGroup userGroup = UserGroup.builder().user(pendingUser).group(group)
+                .joinStatus(JoinStatus.PENDING).build();
+        userGroupRepository.save(userGroup);
+
+        //when //then
+        ApprovalStatus leaderDecision = ApprovalStatus.APPROVED;
+        assertThatThrownBy(
+                () -> groupService.changeJoinApplyStatus(group.getId(), pendingUser.getId(),
+                        leaderUser.getId(), leaderDecision))
+                .isInstanceOf(InvalidAcceptGroupJoinApplyException.class);
+    }
+
+    @Test
+    @DisplayName("그룹 가입을 신청하는 유저는 DB에 저장된 회원이어야 한다")
+    void changeJoinApplyWithoutExistUser() {
+        //given
+        User leaderUser = User.builder().build();
+        User pendingUser = User.builder().id(123L).build();
+        userRepository.save(leaderUser);
+
+        Group group = Group.builder().build();
+        groupRepository.save(group);
+
+        //when //then
+        ApprovalStatus leaderDecision = ApprovalStatus.APPROVED;
+        assertThatThrownBy(
+                () -> groupService.changeJoinApplyStatus(group.getId(), pendingUser.getId(),
+                        leaderUser.getId(), leaderDecision))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+}

--- a/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
@@ -1,0 +1,209 @@
+package seondays.shareticon.docs.group;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import seondays.shareticon.docs.RestDocsSupport;
+import seondays.shareticon.group.Group;
+import seondays.shareticon.group.GroupController;
+import seondays.shareticon.group.GroupService;
+import seondays.shareticon.group.dto.ApplyToJoinRequest;
+import seondays.shareticon.group.dto.ApplyToJoinResponse;
+import seondays.shareticon.group.dto.GroupListResponse;
+import seondays.shareticon.group.dto.GroupResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestBody;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+public class GroupControllerDocsTest extends RestDocsSupport {
+
+    private final GroupService groupService = mock(GroupService.class);
+
+    @Override
+    protected Object initController() {
+        return new GroupController(groupService);
+    }
+
+    @Test
+    @DisplayName("그룹을 새로 생성한다")
+    void createGroupTest() throws Exception {
+        //given
+        Group createdGroup = Group.builder()
+                .id(1L)
+                .inviteCode("ABC")
+                .build();
+
+        when(groupService.createGroup(any(Long.class))).thenReturn(GroupResponse.of(createdGroup));
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.post("/group")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(header().string("Location", "/group/1"))
+                .andDo(document("group-create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("id").type(JsonFieldType.NUMBER)
+                                        .description("생성된 그룹 ID"),
+                                fieldWithPath("inviteCode").type(JsonFieldType.STRING)
+                                        .description("생성된 그룹의 초대코드")
+                        ),
+                        responseHeaders(
+                                headerWithName("Location").description("생성된 그룹 조회 URI")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("유저의 모든 그룹 리스트를 조회한다")
+    void getAllGroupList() throws Exception {
+        //given
+        GroupListResponse response1 = new GroupListResponse(1L);
+        GroupListResponse response2 = new GroupListResponse(2L);
+        List<GroupListResponse> responseList = List.of(response1, response2);
+
+        when(groupService.getAllGroupList(any(Long.class))).thenReturn(responseList);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/group")
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andDo(document("group-get",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("[]").type(JsonFieldType.ARRAY)
+                                        .description("조회된 그룹 리스트"),
+                                fieldWithPath("[].groupId").type(JsonFieldType.NUMBER)
+                                        .description("그룹 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("그룹 가입을 신청한다")
+    void applyToJoinGroup() throws Exception {
+        //given
+        ApplyToJoinRequest request = new ApplyToJoinRequest("inviteCode");
+        String json = new ObjectMapper().writeValueAsString(request);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.post("/group/join")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(json)
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(document("group-join",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("inviteCode").type(JsonFieldType.STRING)
+                                        .description("가입하기를 원하는 그룹의 초대 코드"))
+                ));
+    }
+
+    @Test
+    @DisplayName("유저가 확인할 수 있는 가입 신청 리스트를 조회한다")
+    void getAllApplyToJoinList() throws Exception {
+        //given
+        Long userId = mockUser.getId();
+        String userName = mockUser.getName();
+        ApplyToJoinResponse response1 = new ApplyToJoinResponse(userId, userName, 1L);
+        ApplyToJoinResponse response2 = new ApplyToJoinResponse(userId, userName, 2L);
+        List<ApplyToJoinResponse> responseList = List.of(response1, response2);
+
+        when(groupService.getAllApplyToJoinList(any(Long.class))).thenReturn(responseList);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/group/join")
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andDo(document("group-joinList-get",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("[]").type(JsonFieldType.ARRAY)
+                                        .description("유저가 처리할 수 있는 그룹 가입 신청 리스트"),
+                                fieldWithPath("[].applyUserId").type(JsonFieldType.NUMBER)
+                                        .description("신청한 유저의 ID"),
+                                fieldWithPath("[].pendingUserName").type(JsonFieldType.STRING)
+                                        .description("신청한 유저의 닉네임"),
+                                fieldWithPath("[].targetGroupId").type(JsonFieldType.NUMBER)
+                                        .description("유저가 가입 신청한 그룹 ID")
+                        )));
+    }
+
+    @Test
+    @DisplayName("가입 신청 내역을 처리한다")
+    void approvedJoinApplyStatus() throws Exception {
+        //given
+        Long userId = mockUser.getId();
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.patch("/group/{groupId}/user/{userId}", 1L, userId)
+                                .queryParam("status", "APPROVED")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .with(authentication(auth))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(document("group-JoinList-approved",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("groupId").description("유저가 가입 신청을 한 대상 그룹 ID"),
+                                parameterWithName("userId").description("가입 신청을 한 유저 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("status").description("처리할 상태값. (APPROVED: 승인, REJECTED: 거절)")
+                        )));
+    }
+}


### PR DESCRIPTION
## 연관 이슈
#16 

## 작업 내용
- 각종 리펙토링
- group 컨트롤러, 서비스, 레포지토리, 및 단위 테스트 코드
- Spring REST Docs에 group 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 그룹 생성, 조회, 가입, 가입 요청 처리 등 그룹 관리 관련 API가 추가되었습니다.
  - 그룹 생성 시 고유한 초대 코드가 자동 생성되어 반환됩니다.
  - 초대 코드로 그룹 가입 신청 및 그룹 리더의 가입 승인/거절 기능이 제공됩니다.

- **문서화**
  - 그룹 API에 대한 AsciiDoc 기반 공식 문서가 추가되었습니다.
  - API 사용법, 요청/응답 예시, 필드 설명 등이 문서에 포함되었습니다.

- **버그 수정**
  - 그룹 가입 코드의 중복 여부 검증이 강화되어 안정성이 향상되었습니다.
  - 가입 요청 처리 시 입력 유효성 검사 및 예외 처리가 강화되었습니다.

- **테스트**
  - 그룹 관련 API에 대한 단위 테스트, 통합 테스트, 문서화 테스트가 추가되어 기능 신뢰성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->