### PR TITLE
enhance Voucher entity and image handling with presigned URL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,13 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.security:spring-security-test'
 
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+
+	// objectMapper option for LocalDate
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 	// s3
 	implementation 'software.amazon.awssdk:s3:2.20.89'
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.0.1'
@@ -57,10 +64,6 @@ dependencies {
 	// RestDocs
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-
-	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
-	testImplementation 'org.testcontainers:testcontainers'
-	testImplementation 'org.testcontainers:junit-jupiter'
 }
 
 tasks.named('test') {

--- a/src/main/java/seondays/shareticon/config/S3Config.java
+++ b/src/main/java/seondays/shareticon/config/S3Config.java
@@ -28,7 +28,7 @@ public class S3Config {
 
     }
     @Bean(destroyMethod = "close")
-    public S3Client amazonS3Client(StaticCredentialsProvider credentialsProvider) {
+    public S3Client s3Client(StaticCredentialsProvider credentialsProvider) {
         return S3Client.builder()
                 .region(Region.of(region))
                 .credentialsProvider(credentialsProvider)

--- a/src/main/java/seondays/shareticon/config/S3Config.java
+++ b/src/main/java/seondays/shareticon/config/S3Config.java
@@ -7,11 +7,11 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
 
-    // AWS 인증 정보를 가져오는 변수
     @Value("${aws.s3.access-key}")
     private String accessKey;
 
@@ -22,14 +22,24 @@ public class S3Config {
     private String region;
 
     @Bean
-    public S3Client amazonS3Client() {
-        // AWS 자격 증명 객체 생성
+    public StaticCredentialsProvider awsCredentialsProvider() {
         AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return StaticCredentialsProvider.create(awsCredentials);
 
-        // Amazon S3 클라이언트 빌더를 사용하여 클라이언트 구성
+    }
+    @Bean
+    public S3Client amazonS3Client(StaticCredentialsProvider credentialsProvider) {
         return S3Client.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .credentialsProvider(credentialsProvider)
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner(StaticCredentialsProvider credentialsProvider) {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(credentialsProvider)
                 .build();
     }
 

--- a/src/main/java/seondays/shareticon/config/S3Config.java
+++ b/src/main/java/seondays/shareticon/config/S3Config.java
@@ -27,7 +27,7 @@ public class S3Config {
         return StaticCredentialsProvider.create(awsCredentials);
 
     }
-    @Bean
+    @Bean(destroyMethod = "close")
     public S3Client amazonS3Client(StaticCredentialsProvider credentialsProvider) {
         return S3Client.builder()
                 .region(Region.of(region))
@@ -35,7 +35,7 @@ public class S3Config {
                 .build();
     }
 
-    @Bean
+    @Bean(destroyMethod = "close")
     public S3Presigner s3Presigner(StaticCredentialsProvider credentialsProvider) {
         return S3Presigner.builder()
                 .region(Region.of(region))

--- a/src/main/java/seondays/shareticon/exception/InvalidVoucherExpireException.java
+++ b/src/main/java/seondays/shareticon/exception/InvalidVoucherExpireException.java
@@ -1,0 +1,8 @@
+package seondays.shareticon.exception;
+
+public class InvalidVoucherExpireException extends RuntimeException {
+
+    public InvalidVoucherExpireException() {
+        super("쿠폰 만료일은 오늘보다 이전 날짜로 지정할 수 없습니다");
+    }
+}

--- a/src/main/java/seondays/shareticon/exception/PresignedUrlGenerationException.java
+++ b/src/main/java/seondays/shareticon/exception/PresignedUrlGenerationException.java
@@ -1,0 +1,8 @@
+package seondays.shareticon.exception;
+
+public class PresignedUrlGenerationException extends RuntimeException {
+
+    public PresignedUrlGenerationException() {
+        super("쿠폰 이미지의 Presigned Url 생성 도중 문제가 발생했습니다");
+    }
+}

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -1,26 +1,29 @@
 package seondays.shareticon.image;
 
 import java.io.IOException;
-import java.net.URL;
+import java.time.Duration;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import seondays.shareticon.exception.ImageUploadException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @Service
+@RequiredArgsConstructor
 public class ImageService {
 
     private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
     @Value("${aws.s3.bucket}")
     private String bucket;
-
-    public ImageService(S3Client s3Client) {
-        this.s3Client = s3Client;
-    }
 
     public String uploadImage(MultipartFile image) {
         String uploadTitle = makeUploadTitle("voucher", image.getOriginalFilename());
@@ -37,12 +40,7 @@ public class ImageService {
 
             s3Client.putObject(putObjectRequest, requestBody);
 
-            URL url = s3Client.utilities().getUrl(builder -> builder
-                    .bucket(bucket)
-                    .key(uploadTitle)
-                    .build());
-
-            return url.toString();
+            return uploadTitle;
         } catch (IOException e) {
             throw new ImageUploadException();
         }
@@ -50,5 +48,25 @@ public class ImageService {
 
     public String makeUploadTitle(String prefix, String filename) {
         return prefix + "/" + UUID.randomUUID() + "-" + filename;
+    }
+
+    public String getPreSignedImageUrl(String objectKey, long expirationMinutes) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(objectKey)
+                .build();
+
+        GetObjectPresignRequest presignedUrlGenerationRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(expirationMinutes))
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        try {
+            PresignedGetObjectRequest generatedPresignedUrl = s3Presigner.presignGetObject(
+                    presignedUrlGenerationRequest);
+            return generatedPresignedUrl.url().toString();
+        } catch (Exception e) {
+            throw new ImageUploadException();
+        }
     }
 }

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -50,7 +50,7 @@ public class ImageService {
         return prefix + "/" + UUID.randomUUID() + "-" + filename;
     }
 
-    public String getPreSignedImageUrl(String objectKey, long expirationMinutes) {
+    public String getPresignedImageUrl(String objectKey, Long expirationMinutes) {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucket)
                 .key(objectKey)

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import seondays.shareticon.exception.ImageUploadException;
+import seondays.shareticon.exception.PresignedUrlGenerationException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
@@ -66,7 +67,7 @@ public class ImageService {
                     presignedUrlGenerationRequest);
             return generatedPresignedUrl.url().toString();
         } catch (Exception e) {
-            throw new ImageUploadException();
+            throw new PresignedUrlGenerationException();
         }
     }
 }

--- a/src/main/java/seondays/shareticon/voucher/Voucher.java
+++ b/src/main/java/seondays/shareticon/voucher/Voucher.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -32,6 +33,8 @@ public class Voucher extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String name;
+    private LocalDate expiration;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "group_id")
     private Group group;
@@ -42,10 +45,12 @@ public class Voucher extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private VoucherStatus status;
 
-    public static Voucher createAvailableStatus(User user, Group group) {
+    public static Voucher createAvailableStatus(User user, Group group, String name, LocalDate expiration) {
         return Voucher.builder()
                 .user(user)
                 .group(group)
+                .name(name)
+                .expiration(expiration)
                 .status(VoucherStatus.AVAILABLE)
                 .build();
     }

--- a/src/main/java/seondays/shareticon/voucher/VoucherController.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import seondays.shareticon.login.CustomOAuth2User;
 import seondays.shareticon.voucher.dto.CreateVoucherRequest;
+import seondays.shareticon.voucher.dto.VoucherListResponse;
 import seondays.shareticon.voucher.dto.VouchersResponse;
 
 @RestController
@@ -50,13 +51,13 @@ public class VoucherController {
     }
 
     @GetMapping(value = "/{groupId}")
-    public ResponseEntity<Slice<VouchersResponse>> getAllVoucherInGroup(
+    public ResponseEntity<Slice<VoucherListResponse>> getAllVoucherInGroup(
             @AuthenticationPrincipal CustomOAuth2User userDetails,
             @PathVariable("groupId") Long groupId,
             @RequestParam(required = false) Long cursorId,
             @RequestParam(defaultValue = "10") int pageSize) {
         Long userId = userDetails.getId();
-        Slice<VouchersResponse> response = voucherService.getAllVoucher(userId, groupId,
+        Slice<VoucherListResponse> response = voucherService.getAllVoucher(userId, groupId,
                 cursorId, pageSize);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -58,7 +58,9 @@ public class VoucherService {
         Voucher voucher = createVoucherWithImage(user, group, image, request.voucherName(),
                 request.expiration());
 
-        return VouchersResponse.of(voucher);
+        String preSignedUrl = imageService.getPreSignedImageUrl(voucher.getImage(), 5);
+
+        return VouchersResponse.of(voucher, preSignedUrl);
     }
 
     /**
@@ -116,9 +118,11 @@ public class VoucherService {
                 VoucherStatus.forDisplayVoucherStatus(), cursorId, pageable);
 
         List<VouchersResponse> vouchersResponseList = vouchers.stream()
-                .map(VouchersResponse::of)
+                .map(voucher -> {
+                    String preSignedUrl = imageService.getPreSignedImageUrl(voucher.getImage(), 5);
+                    return VouchersResponse.of(voucher, preSignedUrl);
+                })
                 .toList();
-
         VoucherListResponse voucherListResponse = VoucherListResponse.of(vouchersResponseList,
                 userGroup);
 

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.voucher;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +16,7 @@ import seondays.shareticon.exception.GroupNotFoundException;
 import seondays.shareticon.exception.InvalidAccessVoucherException;
 import seondays.shareticon.exception.InvalidVoucherDeleteException;
 import seondays.shareticon.exception.IllegalVoucherImageException;
+import seondays.shareticon.exception.InvalidVoucherExpireException;
 import seondays.shareticon.exception.UserNotFoundException;
 import seondays.shareticon.exception.VoucherNotFoundException;
 import seondays.shareticon.group.Group;
@@ -37,6 +39,7 @@ public class VoucherService {
     private final GroupRepository groupRepository;
     private final VoucherRepository voucherRepository;
     private final UserGroupRepository userGroupRepository;
+    private final Clock clock;
 
     /**
      * 새로운 쿠폰을 등록합니다
@@ -54,6 +57,7 @@ public class VoucherService {
 
         validateImageFile(image);
         validateUserInGroup(userId, groupId);
+        validateVoucherDateExpiration(request.expiration());
 
         Voucher voucher = createVoucherWithImage(user, group, image, request.voucherName(),
                 request.expiration());
@@ -213,6 +217,13 @@ public class VoucherService {
         String contentType = image.getContentType();
         if (contentType == null || !contentType.startsWith("image")) {
             throw new IllegalVoucherImageException();
+        }
+    }
+
+    private void validateVoucherDateExpiration(LocalDate expiration) {
+        LocalDate today = LocalDate.now(clock);
+        if(expiration.isBefore(today)) {
+            throw new InvalidVoucherExpireException();
         }
     }
 }

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -58,7 +58,7 @@ public class VoucherService {
         Voucher voucher = createVoucherWithImage(user, group, image, request.voucherName(),
                 request.expiration());
 
-        String preSignedUrl = imageService.getPreSignedImageUrl(voucher.getImage(), 5);
+        String preSignedUrl = imageService.getPresignedImageUrl(voucher.getImage(), 5L);
 
         return VouchersResponse.of(voucher, preSignedUrl);
     }
@@ -119,7 +119,7 @@ public class VoucherService {
 
         List<VouchersResponse> vouchersResponseList = vouchers.stream()
                 .map(voucher -> {
-                    String preSignedUrl = imageService.getPreSignedImageUrl(voucher.getImage(), 5);
+                    String preSignedUrl = imageService.getPresignedImageUrl(voucher.getImage(), 5L);
                     return VouchersResponse.of(voucher, preSignedUrl);
                 })
                 .toList();

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.voucher;
 
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -44,7 +45,8 @@ public class VoucherService {
      * @param image
      */
     @Transactional
-    public VouchersResponse register(CreateVoucherRequest request, Long userId, MultipartFile image) {
+    public VouchersResponse register(CreateVoucherRequest request, Long userId,
+            MultipartFile image) {
         Long groupId = request.groupId();
 
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
@@ -53,7 +55,8 @@ public class VoucherService {
         validateImageFile(image);
         validateUserInGroup(userId, groupId);
 
-        Voucher voucher = createVoucherWithImage(user, group, image);
+        Voucher voucher = createVoucherWithImage(user, group, image, request.voucherName(),
+                request.expiration());
 
         return VouchersResponse.of(voucher);
     }
@@ -66,8 +69,9 @@ public class VoucherService {
      * @param image
      * @return
      */
-    private Voucher createVoucherWithImage(User user, Group group, MultipartFile image) {
-        Voucher voucher = Voucher.createAvailableStatus(user, group);
+    private Voucher createVoucherWithImage(User user, Group group, MultipartFile image, String name,
+            LocalDate expiration) {
+        Voucher voucher = Voucher.createAvailableStatus(user, group, name, expiration);
         voucherRepository.save(voucher);
 
         String imageUrl = imageService.uploadImage(image);
@@ -102,7 +106,8 @@ public class VoucherService {
      * @param groupId
      * @return
      */
-    public Slice<VoucherListResponse> getAllVoucher(Long userId, Long groupId, Long cursorId, int size) {
+    public Slice<VoucherListResponse> getAllVoucher(Long userId, Long groupId, Long cursorId,
+            int size) {
         UserGroup userGroup = userGroupRepository.findByUserIdAndGroupId(userId, groupId)
                 .orElseThrow(InvalidAccessVoucherException::new);
 
@@ -114,15 +119,15 @@ public class VoucherService {
                 .map(VouchersResponse::of)
                 .toList();
 
-        VoucherListResponse voucherListResponse = VoucherListResponse.of(vouchersResponseList, userGroup);
+        VoucherListResponse voucherListResponse = VoucherListResponse.of(vouchersResponseList,
+                userGroup);
 
         return new SliceImpl<>(List.of(voucherListResponse), pageable, vouchers.hasNext());
     }
 
     /**
-     * 등록된 쿠폰의 상태를 변경 처리합니다.
-     * 사용가능 쿠폰인 경우 사용완료로, 사용완료 쿠폰인 경우 사용가능으로 변경됩니다.
-     * 만료 쿠폰에 변경을 시도하는 경우에는 예외가 발생합니다.
+     * 등록된 쿠폰의 상태를 변경 처리합니다. 사용가능 쿠폰인 경우 사용완료로, 사용완료 쿠폰인 경우 사용가능으로 변경됩니다. 만료 쿠폰에 변경을 시도하는 경우에는 예외가
+     * 발생합니다.
      *
      * @param userId
      * @param groupId
@@ -144,7 +149,7 @@ public class VoucherService {
 
         if (nowStatus.equals(VoucherStatus.AVAILABLE)) {
             voucher.changeStatus(VoucherStatus.USED);
-        } else if (nowStatus.equals(VoucherStatus.USED)){
+        } else if (nowStatus.equals(VoucherStatus.USED)) {
             voucher.changeStatus(VoucherStatus.AVAILABLE);
         }
     }

--- a/src/main/java/seondays/shareticon/voucher/VoucherStatus.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherStatus.java
@@ -12,6 +12,6 @@ public enum VoucherStatus {
     private final String discription;
 
     public static List<VoucherStatus> forDisplayVoucherStatus() {
-        return List.of(USED, AVAILABLE);
+        return List.of(USED, AVAILABLE, EXPIRED);
     }
 }

--- a/src/main/java/seondays/shareticon/voucher/dto/CreateVoucherRequest.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/CreateVoucherRequest.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.voucher.dto;
 
+import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -10,6 +11,7 @@ public record CreateVoucherRequest(
         @NotEmpty(message = "쿠폰 이름을 포함해야 합니다")
         String voucherName,
         @NotNull(message = "쿠폰의 만료 일자를 포함해야 합니다")
+        @Future(message = "쿠폰의 만료 일자는 오늘보다 이전 날짜로 지정할 수 없습니다")
         LocalDate expiration) {
 
 }

--- a/src/main/java/seondays/shareticon/voucher/dto/CreateVoucherRequest.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/CreateVoucherRequest.java
@@ -1,8 +1,15 @@
 package seondays.shareticon.voucher.dto;
 
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 public record CreateVoucherRequest(
         @NotNull(message = "그룹 ID를 포함해야 합니다")
-        Long groupId) {
+        Long groupId,
+        @NotEmpty(message = "쿠폰 이름을 포함해야 합니다")
+        String voucherName,
+        @NotNull(message = "쿠폰의 만료 일자를 포함해야 합니다")
+        LocalDate expiration) {
+
 }

--- a/src/main/java/seondays/shareticon/voucher/dto/VoucherListResponse.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/VoucherListResponse.java
@@ -1,0 +1,18 @@
+package seondays.shareticon.voucher.dto;
+
+import java.util.List;
+import seondays.shareticon.userGroup.UserGroup;
+
+public record VoucherListResponse(Long groupId,
+                                  String groupTitle,
+                                  List<VouchersResponse> vouchers) {
+
+    public static VoucherListResponse of(List<VouchersResponse> vouchers, UserGroup userGroup) {
+        return new VoucherListResponse(
+                userGroup.getGroup().getId(),
+                userGroup.getGroupTitleAlias(),
+                vouchers
+                );
+    }
+
+}

--- a/src/main/java/seondays/shareticon/voucher/dto/VoucherListResponse.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/VoucherListResponse.java
@@ -5,12 +5,14 @@ import seondays.shareticon.userGroup.UserGroup;
 
 public record VoucherListResponse(Long groupId,
                                   String groupTitle,
+                                  String groupInviteCode,
                                   List<VouchersResponse> vouchers) {
 
     public static VoucherListResponse of(List<VouchersResponse> vouchers, UserGroup userGroup) {
         return new VoucherListResponse(
                 userGroup.getGroup().getId(),
                 userGroup.getGroupTitleAlias(),
+                userGroup.getGroup().getInviteCode(),
                 vouchers
                 );
     }

--- a/src/main/java/seondays/shareticon/voucher/dto/VoucherListResponse.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/VoucherListResponse.java
@@ -3,14 +3,12 @@ package seondays.shareticon.voucher.dto;
 import java.util.List;
 import seondays.shareticon.userGroup.UserGroup;
 
-public record VoucherListResponse(Long groupId,
-                                  String groupTitle,
+public record VoucherListResponse(String groupTitle,
                                   String groupInviteCode,
                                   List<VouchersResponse> vouchers) {
 
     public static VoucherListResponse of(List<VouchersResponse> vouchers, UserGroup userGroup) {
         return new VoucherListResponse(
-                userGroup.getGroup().getId(),
                 userGroup.getGroupTitleAlias(),
                 userGroup.getGroup().getInviteCode(),
                 vouchers

--- a/src/main/java/seondays/shareticon/voucher/dto/VouchersResponse.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/VouchersResponse.java
@@ -1,15 +1,20 @@
 package seondays.shareticon.voucher.dto;
 
+import java.time.LocalDate;
 import seondays.shareticon.voucher.Voucher;
 import seondays.shareticon.voucher.VoucherStatus;
 
 public record VouchersResponse(Long id,
                                String image,
+                               String name,
+                               LocalDate expiration,
                                VoucherStatus status) {
     public static VouchersResponse of(Voucher voucher) {
         return new VouchersResponse(
                 voucher.getId(),
                 voucher.getImage(),
+                voucher.getName(),
+                voucher.getExpiration(),
                 voucher.getStatus()
         );
     }

--- a/src/main/java/seondays/shareticon/voucher/dto/VouchersResponse.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/VouchersResponse.java
@@ -5,14 +5,14 @@ import seondays.shareticon.voucher.Voucher;
 import seondays.shareticon.voucher.VoucherStatus;
 
 public record VouchersResponse(Long id,
-                               String image,
+                               String presignedImage,
                                String name,
                                LocalDate expiration,
                                VoucherStatus status) {
-    public static VouchersResponse of(Voucher voucher) {
+    public static VouchersResponse of(Voucher voucher, String presignedImage) {
         return new VouchersResponse(
                 voucher.getId(),
-                voucher.getImage(),
+                presignedImage,
                 voucher.getName(),
                 voucher.getExpiration(),
                 voucher.getStatus()

--- a/src/test/java/seondays/shareticon/api/config/ControllerTestSupport.java
+++ b/src/test/java/seondays/shareticon/api/config/ControllerTestSupport.java
@@ -17,7 +17,7 @@ import seondays.shareticon.voucher.VoucherService;
         VoucherController.class,
         GroupController.class,
         TokenController.class})
-@Import(TestSecurityConfig.class)
+@Import({TestSecurityConfig.class, TestValidatorConfig.class})
 public abstract class ControllerTestSupport {
 
     @MockitoBean

--- a/src/test/java/seondays/shareticon/api/config/TestValidatorConfig.java
+++ b/src/test/java/seondays/shareticon/api/config/TestValidatorConfig.java
@@ -1,0 +1,31 @@
+package seondays.shareticon.api.config;
+
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestValidatorConfig {
+
+    // DTO 검증을 수행할 validator에서 우리가 지정한 clock 객체를 사용하도록 설정한다
+    @Bean
+    public Validator validator(Clock clock) {
+        ValidatorFactory factory = Validation.byDefaultProvider()
+                .configure()
+                .clockProvider(() -> clock)
+                .buildValidatorFactory();
+        return factory.getValidator();
+    }
+
+    @Bean
+    public Clock clock() {
+        return Clock.fixed(Instant.parse("2024-12-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+    }
+
+}
+

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
@@ -2,6 +2,8 @@ package seondays.shareticon.api.voucher;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,7 +16,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -53,7 +54,11 @@ public class VoucherControllerTest extends ControllerTestSupport {
     @DisplayName("신규 쿠폰을 생성한다")
     void registerVoucher() throws Exception {
         //given
-        CreateVoucherRequest request = new CreateVoucherRequest(1L);
+        Long groupId = 1L;
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+
+        CreateVoucherRequest request = new CreateVoucherRequest(groupId, voucherName, expiration);
         String jsonRequest = objectMapper.writeValueAsString(request);
 
         MockMultipartFile imagePart = new MockMultipartFile(
@@ -71,7 +76,8 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 jsonRequest.getBytes(StandardCharsets.UTF_8)
         );
 
-        VouchersResponse mockResponse = new VouchersResponse(1L, "image", VoucherStatus.AVAILABLE);
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
+                VoucherStatus.AVAILABLE);
 
         when(voucherService.register(
                 any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
@@ -90,13 +96,22 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 .andExpect(MockMvcResultMatchers.status().isCreated())
                 .andExpect(header().string("Location", "/vouchers/1"))
                 .andExpect(jsonPath("$.id").value(1L))
-                .andExpect(jsonPath("$.status").value("AVAILABLE"));
+                .andExpect(jsonPath("$.status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.image").value("image"))
+                .andExpect(jsonPath("$.name").value(voucherName))
+                .andExpect(jsonPath("$.expiration").value(
+                        expiration.format(DateTimeFormatter.ISO_LOCAL_DATE)));
     }
 
     @Test
     @DisplayName("신규 쿠폰을 등록할 때 그룹 아이디는 필수이다")
     void registerVoucherWithNoGroupId() throws Exception {
-        String emptyRequest = "{}";
+        Long groupId = null;
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+
+        CreateVoucherRequest request = new CreateVoucherRequest(groupId, voucherName, expiration);
+        String jsonRequestWithoutGroupId = objectMapper.writeValueAsString(request);
 
         MockMultipartFile imagePart = new MockMultipartFile(
                 "image",
@@ -109,10 +124,11 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 "request",
                 null,
                 "application/json",
-                emptyRequest.getBytes(StandardCharsets.UTF_8)
+                jsonRequestWithoutGroupId.getBytes(StandardCharsets.UTF_8)
         );
 
-        VouchersResponse mockResponse = new VouchersResponse(1L, "image", VoucherStatus.AVAILABLE);
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
+                VoucherStatus.AVAILABLE);
 
         when(voucherService.register(
                 any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
@@ -130,6 +146,100 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("그룹 ID를 포함해야 합니다"))
+                .andExpect(jsonPath("$.code").value("400"));
+
+    }
+
+    @Test
+    @DisplayName("신규 쿠폰을 생성할 때 쿠폰 이름은 필수이다")
+    void registerVoucherWithNoVoucherName() throws Exception {
+        Long groupId = 1L;
+        String voucherName = "";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+
+        CreateVoucherRequest request = new CreateVoucherRequest(groupId, voucherName, expiration);
+        String jsonRequestWithoutGroupId = objectMapper.writeValueAsString(request);
+
+        MockMultipartFile imagePart = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test".getBytes()
+        );
+
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request",
+                null,
+                "application/json",
+                jsonRequestWithoutGroupId.getBytes(StandardCharsets.UTF_8)
+        );
+
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
+                VoucherStatus.AVAILABLE);
+
+        when(voucherService.register(
+                any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
+                .thenReturn(mockResponse);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.multipart("/vouchers")
+                                .file(imagePart)
+                                .file(requestPart)
+                                .with(csrf())
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("쿠폰 이름을 포함해야 합니다"))
+                .andExpect(jsonPath("$.code").value("400"));
+
+    }
+
+    @Test
+    @DisplayName("신규 쿠폰을 생성할 때 쿠폰의 만료 일자는 필수이다")
+    void registerVoucherWithNoVoucherExpiration() throws Exception {
+        Long groupId = 1L;
+        String voucherName = "voucher name";
+        LocalDate expiration = null;
+
+        CreateVoucherRequest request = new CreateVoucherRequest(groupId, voucherName, expiration);
+        String jsonRequestWithoutGroupId = objectMapper.writeValueAsString(request);
+
+        MockMultipartFile imagePart = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test".getBytes()
+        );
+
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request",
+                null,
+                "application/json",
+                jsonRequestWithoutGroupId.getBytes(StandardCharsets.UTF_8)
+        );
+
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
+                VoucherStatus.AVAILABLE);
+
+        when(voucherService.register(
+                any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
+                .thenReturn(mockResponse);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.multipart("/vouchers")
+                                .file(imagePart)
+                                .file(requestPart)
+                                .with(csrf())
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("쿠폰의 만료 일자를 포함해야 합니다"))
                 .andExpect(jsonPath("$.code").value("400"));
 
     }
@@ -207,6 +317,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 .build();
         Group group = Group.builder()
                 .id(groupId)
+                .inviteCode("InviteCode")
                 .build();
         User user = User.builder()
                 .id(userId)
@@ -253,7 +364,8 @@ public class VoucherControllerTest extends ControllerTestSupport {
         Slice<VoucherListResponse> mockSlice =
                 new SliceImpl<>(Collections.emptyList(), Pageable.ofSize(pageSize), false);
 
-        when(voucherService.getAllVoucher(eq(mockUser.getId()), eq(groupId), eq(cursorId), eq(pageSize)))
+        when(voucherService.getAllVoucher(eq(mockUser.getId()), eq(groupId), eq(cursorId),
+                eq(pageSize)))
                 .thenReturn(mockSlice);
 
         //when //then
@@ -278,10 +390,11 @@ public class VoucherControllerTest extends ControllerTestSupport {
 
         //when //then
         mockMvc.perform(
-                MockMvcRequestBuilders.patch("/vouchers/group/{groupId}/voucher/{voucherId}", groupId, voucherId)
-                        .with(csrf())
-                        .with(oauth2Login().oauth2User(mockUser))
-        )
+                        MockMvcRequestBuilders.patch("/vouchers/group/{groupId}/voucher/{voucherId}",
+                                        groupId, voucherId)
+                                .with(csrf())
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk());
     }
@@ -295,7 +408,8 @@ public class VoucherControllerTest extends ControllerTestSupport {
 
         //when //then
         mockMvc.perform(
-                        MockMvcRequestBuilders.patch("/vouchers/group/{groupId}/voucher/{voucherId}", groupId, voucherId)
+                        MockMvcRequestBuilders.patch("/vouchers/group/{groupId}/voucher/{voucherId}",
+                                        groupId, voucherId)
                                 .with(csrf())
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
@@ -313,7 +427,8 @@ public class VoucherControllerTest extends ControllerTestSupport {
 
         //when //then
         mockMvc.perform(
-                        MockMvcRequestBuilders.patch("/vouchers/group/{groupId}/voucher/{voucherId}", groupId, voucherId)
+                        MockMvcRequestBuilders.patch("/vouchers/group/{groupId}/voucher/{voucherId}",
+                                        groupId, voucherId)
                                 .with(csrf())
                                 .with(oauth2Login().oauth2User(mockUser))
                 )

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
@@ -34,6 +34,7 @@ import seondays.shareticon.voucher.dto.VouchersResponse;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
@@ -97,7 +98,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 .andExpect(header().string("Location", "/vouchers/1"))
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.status").value("AVAILABLE"))
-                .andExpect(jsonPath("$.image").value("image"))
+                .andExpect(jsonPath("$.presignedImage").value("image"))
                 .andExpect(jsonPath("$.name").value(voucherName))
                 .andExpect(jsonPath("$.expiration").value(
                         expiration.format(DateTimeFormatter.ISO_LOCAL_DATE)));
@@ -309,6 +310,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
         Long voucherId = 1L;
         Long cursorId = 1L;
         int pageSize = 1;
+        String mockPresignedUrl = "mockPresignedUrl";
 
         Voucher voucher = Voucher.builder()
                 .id(voucherId)
@@ -328,7 +330,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 .groupTitleAlias("나의 그룹 이름")
                 .build();
         List<VoucherListResponse> mockResponse = List.of(
-                VoucherListResponse.of(List.of(VouchersResponse.of(voucher)), userGroup));
+                VoucherListResponse.of(List.of(VouchersResponse.of(voucher, mockPresignedUrl)), userGroup));
 
         Slice<VoucherListResponse> mockSlice =
                 new SliceImpl<>(mockResponse, PageRequest.of(0, pageSize), false);

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
@@ -34,7 +34,6 @@ import seondays.shareticon.voucher.dto.VouchersResponse;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
@@ -241,6 +240,57 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("쿠폰의 만료 일자를 포함해야 합니다"))
+                .andExpect(jsonPath("$.code").value("400"));
+
+    }
+
+    @Test
+    @DisplayName("신규 쿠폰을 생성할 때 생성 날짜보다 이전 날짜를 만료 일자로 지정할 수 없다")
+    void registerVoucherWithNoVoucherExpirationBeforeToday() throws Exception {
+        Long groupId = 1L;
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2024,11,30);
+
+        CreateVoucherRequest request = new CreateVoucherRequest(groupId, voucherName, expiration);
+        String jsonRequestWithoutGroupId = objectMapper.writeValueAsString(request);
+
+        MockMultipartFile imagePart = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test".getBytes()
+        );
+
+        MockMultipartFile requestPart = new MockMultipartFile(
+                "request",
+                null,
+                "application/json",
+                jsonRequestWithoutGroupId.getBytes(StandardCharsets.UTF_8)
+        );
+
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
+                VoucherStatus.AVAILABLE);
+
+        when(voucherService.register(
+                any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
+                .thenReturn(mockResponse);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.multipart("/vouchers")
+                                .file(imagePart)
+                                .file(requestPart)
+                                .with(csrf())
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(result -> {
+                    Exception resolvedException = result.getResolvedException();
+                    resolvedException.printStackTrace();
+                })
+                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("쿠폰의 만료 일자는 오늘보다 이전 날짜로 지정할 수 없습니다"))
                 .andExpect(jsonPath("$.code").value("400"));
 
     }

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
@@ -137,7 +137,7 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
     }
 
     @Test
-    @DisplayName("사용가능, 사용완료 상태인 쿠폰만 조회된다")
+    @DisplayName("사용가능, 사용완료, 사용만료 상태인 쿠폰만 조회된다")
     void getVoucherStatusUsedAndAvailable() {
         //given
         Group group = Group.builder()
@@ -153,7 +153,7 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
 
         List<VoucherStatus> voucherStatuses = VoucherStatus.forDisplayVoucherStatus();
 
-        Pageable pageable = PageRequest.of(0, 3);
+        Pageable pageable = PageRequest.of(0, 5);
 
         //when
         Slice<Voucher> result = voucherRepository.findAllPageWithCursorByDesc(
@@ -162,7 +162,8 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         //then
         assertThat(result.getContent()).extracting("status")
                 .containsExactlyInAnyOrder(
-                        VoucherStatus.AVAILABLE, VoucherStatus.USED, VoucherStatus.AVAILABLE);
+                        VoucherStatus.AVAILABLE, VoucherStatus.USED, VoucherStatus.EXPIRED,
+                        VoucherStatus.AVAILABLE, VoucherStatus.EXPIRED);
     }
 
     @Test

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -75,7 +76,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
         linkUserWithGroup(user, group);
 
-        CreateVoucherRequest request = new CreateVoucherRequest(group.getId());
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        CreateVoucherRequest request = new CreateVoucherRequest(group.getId(), voucherName,
+                expiration);
 
         MockMultipartFile mockImage = new MockMultipartFile(
                 "test",
@@ -111,7 +115,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
         linkUserWithGroup(user, group);
 
-        CreateVoucherRequest request = new CreateVoucherRequest(group.getId());
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        CreateVoucherRequest request = new CreateVoucherRequest(group.getId(), voucherName,
+                expiration);
 
         MockMultipartFile mockImage = new MockMultipartFile(
                 "test",
@@ -136,7 +143,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
         groupRepository.save(group);
 
-        CreateVoucherRequest request = new CreateVoucherRequest(group.getId());
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        CreateVoucherRequest request = new CreateVoucherRequest(group.getId(), voucherName,
+                expiration);
 
         MockMultipartFile mockImage = new MockMultipartFile(
                 "test",
@@ -160,7 +170,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
 
         Long noExistUserId = 1L;
-        CreateVoucherRequest request = new CreateVoucherRequest(group.getId());
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        CreateVoucherRequest request = new CreateVoucherRequest(group.getId(), voucherName,
+                expiration);
 
         MockMultipartFile mockImage = new MockMultipartFile(
                 "test",
@@ -185,7 +198,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
 
         Long noExistGroupId = 1L;
-        CreateVoucherRequest request = new CreateVoucherRequest(noExistGroupId);
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        CreateVoucherRequest request = new CreateVoucherRequest(noExistGroupId, voucherName,
+                expiration);
 
         MockMultipartFile mockImage = new MockMultipartFile(
                 "test",
@@ -212,7 +228,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
         linkUserWithGroup(user, group);
 
-        CreateVoucherRequest request = new CreateVoucherRequest(group.getId());
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        CreateVoucherRequest request = new CreateVoucherRequest(group.getId(), voucherName,
+                expiration);
 
         MockMultipartFile mockImage = new MockMultipartFile(
                 "test",
@@ -244,7 +263,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
         linkUserWithGroup(user, group);
 
-        Voucher voucher = Voucher.createAvailableStatus(user, group);
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+
+        Voucher voucher = Voucher.createAvailableStatus(user, group, voucherName, expiration);
         voucherRepository.save(voucher);
 
         //when
@@ -269,7 +291,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         linkUserWithGroup(registerUser, group);
         linkUserWithGroup(NotRegisterUser, group);
 
-        Voucher voucher = Voucher.createAvailableStatus(registerUser, group);
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        Voucher voucher = Voucher.createAvailableStatus(registerUser, group, voucherName,
+                expiration);
         voucherRepository.save(voucher);
 
         //when //then
@@ -291,7 +316,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
         linkUserWithGroup(userExistInGroup, group);
 
-        Voucher voucher = Voucher.createAvailableStatus(userExistInGroup, group);
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        Voucher voucher = Voucher.createAvailableStatus(userExistInGroup, group, voucherName,
+                expiration);
         voucherRepository.save(voucher);
 
         //when //then
@@ -301,6 +329,7 @@ class VoucherServiceTest extends IntegrationTestSupport {
     }
 
     @Test
+    @Transactional
     @DisplayName("그룹에 속해있는 사용자가 쿠폰을 조회하는 경우 전체 쿠폰 결과를 담은 slice를 반환한다")
     void getAllVoucherWithUserExistInGroup() {
         //given
@@ -311,9 +340,11 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
         linkUserWithGroup(user, group);
 
-        Voucher voucher1 = Voucher.createAvailableStatus(user, group);
-        Voucher voucher2 = Voucher.createAvailableStatus(user, group);
-        Voucher voucher3 = Voucher.createAvailableStatus(user, group);
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        Voucher voucher1 = Voucher.createAvailableStatus(user, group, voucherName, expiration);
+        Voucher voucher2 = Voucher.createAvailableStatus(user, group, voucherName, expiration);
+        Voucher voucher3 = Voucher.createAvailableStatus(user, group, voucherName, expiration);
         voucher1.saveImage("image1");
         voucher2.saveImage("image2");
         voucher3.saveImage("image3");
@@ -343,6 +374,7 @@ class VoucherServiceTest extends IntegrationTestSupport {
     }
 
     @Test
+    @Transactional
     @DisplayName("그룹에 속해있는 사용자가 쿠폰을 조회하는 경우, 쿠폰이 존재하지 않더라도 해당 그룹 정보는 결과에 포함된다")
     void getAllVoucherWithUserExistInGroupAndNoVoucher() {
         //given
@@ -378,9 +410,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         Group group = Group.builder().build();
         groupRepository.save(group);
 
-        Voucher voucher1 = Voucher.createAvailableStatus(user, group);
-        Voucher voucher2 = Voucher.createAvailableStatus(user, group);
-        Voucher voucher3 = Voucher.createAvailableStatus(user, group);
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        Voucher voucher1 = Voucher.createAvailableStatus(user, group, "voucher name1", expiration);
+        Voucher voucher2 = Voucher.createAvailableStatus(user, group, "voucher name2", expiration);
+        Voucher voucher3 = Voucher.createAvailableStatus(user, group, "voucher name3", expiration);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
 
         //when //then
@@ -400,7 +433,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
         linkUserWithGroup(user, group);
 
-        Voucher voucher = Voucher.createAvailableStatus(user, group);
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+        Voucher voucher = Voucher.createAvailableStatus(user, group, voucherName, expiration);
         voucherRepository.save(voucher);
 
         return Stream.of(

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -92,6 +92,8 @@ class VoucherServiceTest extends IntegrationTestSupport {
         given(imageService.uploadImage(any()))
                 .willReturn("https://test/test.jpg");
 
+        given(imageService.getPresignedImageUrl(any(), any())).willReturn("presignedImageUrl");
+
         VouchersResponse response = voucherService.register(request, user.getId(), mockImage);
 
         //then
@@ -352,6 +354,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
 
         //when
+        String preSignedImageUrl = "presignedImageUrlResult";
+        given(imageService.getPresignedImageUrl(any(), any())).willReturn(preSignedImageUrl);
+
         Slice<VoucherListResponse> allVoucher = voucherService.getAllVoucher(user.getId(),
                 group.getId(), null, 3);
 
@@ -364,11 +369,11 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
         assertThat(voucherListResponse.groupId()).isEqualTo(group.getId());
         assertThat(voucherListResponse.vouchers())
-                .extracting("id", "image", "status")
+                .extracting("id", "presignedImage", "status")
                 .contains(
-                        tuple(voucher1.getId(),voucher1.getImage(), voucher1.getStatus()),
-                        tuple(voucher2.getId(),voucher2.getImage(), voucher2.getStatus()),
-                        tuple(voucher3.getId(),voucher3.getImage(), voucher3.getStatus())
+                        tuple(voucher1.getId(), preSignedImageUrl, voucher1.getStatus()),
+                        tuple(voucher2.getId(), preSignedImageUrl, voucher2.getStatus()),
+                        tuple(voucher3.getId(), preSignedImageUrl, voucher3.getStatus())
                 );
 
     }

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -85,9 +85,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         User user = User.builder()
                 .build();
         Group group = Group.builder().inviteCode("123").build();
+        String userGroupAlias = "그룹 별칭";
         userRepository.save(user);
         groupRepository.save(group);
-        linkUserWithGroup(user, group);
+        linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -126,9 +127,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         User user = User.builder()
                 .build();
         Group group = Group.builder().build();
+        String userGroupAlias = "그룹 별칭";
         userRepository.save(user);
         groupRepository.save(group);
-        linkUserWithGroup(user, group);
+        linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -239,9 +241,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         User user = User.builder()
                 .build();
         Group group = Group.builder().build();
+        String userGroupAlias = "그룹 별칭";
         userRepository.save(user);
         groupRepository.save(group);
-        linkUserWithGroup(user, group);
+        linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -275,8 +278,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
 
         Group group = Group.builder().build();
+        String userGroupAlias = "그룹 별칭";
         groupRepository.save(group);
-        linkUserWithGroup(user, group);
+        linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -302,9 +306,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         userRepository.save(NotRegisterUser);
 
         Group group = Group.builder().build();
+        String userGroupAlias = "그룹 별칭";
         groupRepository.save(group);
-        linkUserWithGroup(registerUser, group);
-        linkUserWithGroup(NotRegisterUser, group);
+        linkUserWithGroup(registerUser, group, userGroupAlias);
+        linkUserWithGroup(NotRegisterUser, group, userGroupAlias);
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -328,8 +333,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
         userRepository.save(userNoExistInGroup);
 
         Group group = Group.builder().build();
+        String userGroupAlias = "그룹 별칭";
         groupRepository.save(group);
-        linkUserWithGroup(userExistInGroup, group);
+        linkUserWithGroup(userExistInGroup, group, userGroupAlias);
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -352,8 +358,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
 
         Group group = Group.builder().build();
+        String userGroupAlias = "그룹 별칭";
         groupRepository.save(group);
-        linkUserWithGroup(user, group);
+        UserGroup userGroup = linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -380,7 +387,7 @@ class VoucherServiceTest extends IntegrationTestSupport {
         assertThat(allVoucher.getSize()).isEqualTo(3);
         assertThat(allVoucher.getNumberOfElements()).isEqualTo(1);
 
-        assertThat(voucherListResponse.groupId()).isEqualTo(group.getId());
+        assertThat(voucherListResponse.groupTitle()).isEqualTo(userGroup.getGroupTitleAlias());
         assertThat(voucherListResponse.vouchers())
                 .extracting("id", "presignedImage", "status")
                 .contains(
@@ -399,9 +406,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().build();
+        Group group = Group.builder().title("나의 그룹").build();
+        String userGroupAlias = "그룹 별칭";
         groupRepository.save(group);
-        linkUserWithGroup(user, group);
+        linkUserWithGroup(user, group, userGroupAlias);
 
         //when
         Slice<VoucherListResponse> allVoucher = voucherService.getAllVoucher(user.getId(),
@@ -415,7 +423,7 @@ class VoucherServiceTest extends IntegrationTestSupport {
         assertThat(allVoucher.getNumberOfElements()).isEqualTo(1);
 
         assertThat(voucherListResponse.vouchers()).isEmpty();
-        assertThat(voucherListResponse.groupId()).isEqualTo(group.getId());
+        assertThat(voucherListResponse.groupTitle()).isEqualTo(userGroupAlias);
     }
 
     @Test
@@ -448,8 +456,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
         userRepository.save(user);
 
         Group group = Group.builder().build();
+        String userGroupAlias = "그룹 별칭";
         groupRepository.save(group);
-        linkUserWithGroup(user, group);
+        linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -476,8 +485,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
         );
     }
 
-    private void linkUserWithGroup(User user, Group group) {
-        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
+    private UserGroup linkUserWithGroup(User user, Group group, String alias) {
+        UserGroup userGroup = UserGroup.builder().user(user).group(group).groupTitleAlias(alias).build();
         userGroupRepository.save(userGroup);
+        return userGroup;
     }
 }

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -5,12 +5,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;
@@ -56,6 +60,15 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private UserGroupRepository userGroupRepository;
+
+    private Instant testSystemTimeInstant;
+
+    @BeforeEach
+    void setUp() {
+        testSystemTimeInstant = Instant.parse("2024-12-01T00:00:00Z");
+        when(clock.instant()).thenReturn(testSystemTimeInstant);
+        when(clock.getZone()).thenReturn(ZoneId.of("Asia/Seoul"));
+    }
 
     @AfterEach
     void tearDown() {

--- a/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
+++ b/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
@@ -5,6 +5,12 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.validation.Validation;
+import jakarta.validation.ValidatorFactory;
+import org.springframework.validation.Validator;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -16,6 +22,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.method.annotation.AuthenticationPrincipalArgumentResolver;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter;
 import seondays.shareticon.login.CustomOAuth2User;
 import seondays.shareticon.user.dto.UserOAuth2Dto;
 
@@ -34,10 +41,12 @@ public abstract class RestDocsSupport {
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 
         // setMessageConverters를 통해 mockMvc의 LocalDate 역직렬화를 위한 컨버터 추가
+        // DTO 검증을 수행할 validator에서 우리가 지정한 clock 객체를 사용하도록 직접 설정
         this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
                 .apply(documentationConfiguration(provider))
                 .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
                 .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
+                .setValidator(validator(clock()))
                 .build();
 
         mockUser = new CustomOAuth2User(new UserOAuth2Dto(1L, "user", "ROLE_USER"));
@@ -47,4 +56,17 @@ public abstract class RestDocsSupport {
     }
 
     protected abstract Object initController();
+
+
+    private Validator validator(Clock clock) {
+        ValidatorFactory factory = Validation.byDefaultProvider()
+                .configure()
+                .clockProvider(() -> clock)
+                .buildValidatorFactory();
+        return new SpringValidatorAdapter(factory.getValidator());
+    }
+
+    private Clock clock() {
+        return Clock.fixed(Instant.parse("2024-12-01T00:00:00Z"), ZoneId.of("Asia/Seoul"));
+    }
 }

--- a/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
+++ b/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
@@ -3,8 +3,11 @@ package seondays.shareticon.docs;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -26,9 +29,15 @@ public abstract class RestDocsSupport {
 
     @BeforeEach
     void setUp(RestDocumentationContextProvider provider) {
+        // objectMapper가 LocalDate YYYY-MM-DD 형식을 직렬화 할 수 있도록 설정 추가
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+
+        // setMessageConverters를 통해 mockMvc의 LocalDate 역직렬화를 위한 컨버터 추가
         this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
                 .apply(documentationConfiguration(provider))
                 .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
+                .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
                 .build();
 
         mockUser = new CustomOAuth2User(new UserOAuth2Dto(1L, "user", "ROLE_USER"));

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -23,7 +23,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -62,7 +63,11 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
     @DisplayName("신규 쿠폰을 생성한다")
     void registerVoucher() throws Exception {
         //given
-        CreateVoucherRequest request = new CreateVoucherRequest(1L);
+        Long groupId = 1L;
+        String voucherName = "voucher name";
+        LocalDate expiration = LocalDate.of(2025, 1, 1);
+
+        CreateVoucherRequest request = new CreateVoucherRequest(groupId, voucherName, expiration);
         String jsonRequest = objectMapper.writeValueAsString(request);
 
         MockMultipartFile imagePart = new MockMultipartFile(
@@ -79,7 +84,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                 jsonRequest.getBytes(StandardCharsets.UTF_8)
         );
 
-        VouchersResponse mockResponse = new VouchersResponse(1L, "voucherImage",
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
                 VoucherStatus.AVAILABLE);
 
         when(voucherService.register(
@@ -99,6 +104,10 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                 .andExpect(header().string("Location", "/vouchers/1"))
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.status").value("AVAILABLE"))
+                .andExpect(jsonPath("$.image").value("image"))
+                .andExpect(jsonPath("$.name").value(voucherName))
+                .andExpect(jsonPath("$.expiration").value(
+                        expiration.format(DateTimeFormatter.ISO_LOCAL_DATE)))
                 .andDo(document("voucher-create",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
@@ -108,17 +117,23 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                         ),
                         requestPartFields("request",
                                 fieldWithPath("groupId").type(JsonFieldType.NUMBER)
-                                        .description("쿠폰을 저장할 그룹 ID")
+                                        .description("쿠폰을 저장할 그룹 ID"),
+                                fieldWithPath("voucherName").type(JsonFieldType.STRING)
+                                        .description("저장할 쿠폰의 이름"),
+                                fieldWithPath("expiration").type(JsonFieldType.STRING)
+                                        .description("저장할 쿠폰의 만료 기간")
                         ),
                         responseFields(
-
                                 fieldWithPath("id").type(JsonFieldType.NUMBER)
                                         .description("생성된 쿠폰 ID"),
                                 fieldWithPath("image").type(JsonFieldType.STRING)
                                         .description("이미지 URL"),
                                 fieldWithPath("status").type(JsonFieldType.STRING)
-                                        .description("쿠폰 상태 (AVAILABLE/EXPIRED/USED)")
-
+                                        .description("쿠폰 상태 (AVAILABLE/EXPIRED/USED)"),
+                                fieldWithPath("name").type(JsonFieldType.STRING)
+                                        .description("쿠폰 등록자가 설정한 쿠폰의 이름"),
+                                fieldWithPath("expiration").type(JsonFieldType.STRING)
+                                        .description("쿠폰 등록자가 설정한 쿠폰의 만료 기간")
                         )
                 ));
     }
@@ -157,14 +172,19 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
         Long voucherId = 1L;
         Long cursorId = 1L;
         int pageSize = 1;
+        String voucherName = "my voucherName";
+        LocalDate expiration = LocalDate.of(2025,1,1);
 
         Voucher voucher = Voucher.builder()
                 .id(voucherId)
                 .image("www.image.com")
                 .status(VoucherStatus.AVAILABLE)
+                .name(voucherName)
+                .expiration(expiration)
                 .build();
         Group group = Group.builder()
                 .id(groupId)
+                .inviteCode("InviteCode")
                 .build();
         User user = User.builder()
                 .id(userId)
@@ -215,6 +235,8 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                         .description("해당 쿠폰 객체가 속해있는 그룹 ID"),
                                 fieldWithPath("content[].groupTitle").type(JsonFieldType.STRING)
                                         .description("해당 쿠폰 객체가 속해있는 그룹의 사용자별 별칭"),
+                                fieldWithPath("content[].groupInviteCode").type(JsonFieldType.STRING)
+                                                .description("해당 쿠폰 객체가 속해있는 그룹의 초대코드"),
                                 fieldWithPath("content[].vouchers[].id").type(JsonFieldType.NUMBER)
                                         .description("쿠폰 ID"),
                                 fieldWithPath("content[].vouchers[].image").type(
@@ -222,7 +244,11 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                         .description("쿠폰 이미지 URL"),
                                 fieldWithPath("content[].vouchers[].status").type(
                                                 JsonFieldType.STRING)
-                                        .description("쿠폰 사용 상태"),
+                                        .description("쿠폰 사용 상태 (AVAILABLE/EXPIRED/USED)"),
+                                fieldWithPath("content[].vouchers[].name").type(JsonFieldType.STRING)
+                                                .description("쿠폰 등록자가 설정한 쿠폰의 이름"),
+                                fieldWithPath("content[].vouchers[].expiration").type(JsonFieldType.STRING)
+                                                .description("쿠폰 등록자가 설정한 쿠폰의 만료 기간"),
 
                                 subsectionWithPath("pageable").type(JsonFieldType.OBJECT)
                                         .description("페이지네이션 요청 정보"),

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -104,7 +104,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                 .andExpect(header().string("Location", "/vouchers/1"))
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.status").value("AVAILABLE"))
-                .andExpect(jsonPath("$.image").value("image"))
+                .andExpect(jsonPath("$.presignedImage").value("image"))
                 .andExpect(jsonPath("$.name").value(voucherName))
                 .andExpect(jsonPath("$.expiration").value(
                         expiration.format(DateTimeFormatter.ISO_LOCAL_DATE)))
@@ -126,7 +126,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                         responseFields(
                                 fieldWithPath("id").type(JsonFieldType.NUMBER)
                                         .description("생성된 쿠폰 ID"),
-                                fieldWithPath("image").type(JsonFieldType.STRING)
+                                fieldWithPath("presignedImage").type(JsonFieldType.STRING)
                                         .description("이미지 URL"),
                                 fieldWithPath("status").type(JsonFieldType.STRING)
                                         .description("쿠폰 상태 (AVAILABLE/EXPIRED/USED)"),
@@ -174,6 +174,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
         int pageSize = 1;
         String voucherName = "my voucherName";
         LocalDate expiration = LocalDate.of(2025,1,1);
+        String mockPresignedUrl = "mockPresignedUrl";
 
         Voucher voucher = Voucher.builder()
                 .id(voucherId)
@@ -194,8 +195,9 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                 .group(group)
                 .groupTitleAlias("나의 그룹 이름")
                 .build();
+
         List<VoucherListResponse> mockResponse = List.of(
-                VoucherListResponse.of(List.of(VouchersResponse.of(voucher)), userGroup));
+                VoucherListResponse.of(List.of(VouchersResponse.of(voucher, mockPresignedUrl)), userGroup));
 
         Slice<VoucherListResponse> mockSlice =
                 new SliceImpl<>(mockResponse, PageRequest.of(0, pageSize), false);
@@ -239,7 +241,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                                 .description("해당 쿠폰 객체가 속해있는 그룹의 초대코드"),
                                 fieldWithPath("content[].vouchers[].id").type(JsonFieldType.NUMBER)
                                         .description("쿠폰 ID"),
-                                fieldWithPath("content[].vouchers[].image").type(
+                                fieldWithPath("content[].vouchers[].presignedImage").type(
                                                 JsonFieldType.STRING)
                                         .description("쿠폰 이미지 URL"),
                                 fieldWithPath("content[].vouchers[].status").type(

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -233,8 +233,6 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                         responseFields(
                                 fieldWithPath("content").type(JsonFieldType.ARRAY)
                                         .description("조회된 쿠폰 객체들의 배열"),
-                                fieldWithPath("content[].groupId").type(JsonFieldType.NUMBER)
-                                        .description("해당 쿠폰 객체가 속해있는 그룹 ID"),
                                 fieldWithPath("content[].groupTitle").type(JsonFieldType.STRING)
                                         .description("해당 쿠폰 객체가 속해있는 그룹의 사용자별 별칭"),
                                 fieldWithPath("content[].groupInviteCode").type(JsonFieldType.STRING)


### PR DESCRIPTION
## 연관 이슈
close #23, #24, #25

## 작업 내용
- 쿠폰 엔티티가 이름과 만료 날짜를 가지도록 변경
- 쿠폰 전체 조회 시, 해당 그룹의 별칭과 id가 포함되도록 변경
- 쿠폰 이미지 관련 작업 시 presigned URL 을 이용하도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 쿠폰 생성 시 이름과 만료일 입력 필드가 추가되었습니다.
  - 쿠폰 이미지에 대해 만료기간이 지정된 presigned URL을 제공합니다.
  - 쿠폰 목록 조회 시 그룹 정보(그룹 이름, 초대코드)와 함께 쿠폰 리스트가 반환됩니다.

- **버그 수정**
  - LocalDate(날짜) 타입의 직렬화/역직렬화가 올바르게 처리됩니다.

- **리팩터**
  - AWS S3 Presigner 및 자격 증명 분리로 S3 연동 구조가 개선되었습니다.

- **테스트**
  - 쿠폰 이름/만료일 필수 검증, presigned URL 반환, 그룹 정보 포함 응답 등 새로운 테스트 케이스가 추가 및 개선되었습니다.
  - 날짜 타입 직렬화 및 고정 시계 기반 검증 테스트 환경이 보완되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->