### PR TITLE
add User info & join group list

### DIFF
--- a/src/docs/asciidoc/api/group/group.adoc
+++ b/src/docs/asciidoc/api/group/group.adoc
@@ -22,6 +22,13 @@ include::{snippets}/group-join/request-fields.adoc[]
 ==== HTTP Response
 include::{snippets}/group-join/http-response.adoc[]
 
+=== 그룹 가입 신청 내역 조회
+==== HTTP Request
+include::{snippets}/group-joinList-get/http-request.adoc[]
+==== HTTP Response
+include::{snippets}/group-joinList-get/http-response.adoc[]
+include::{snippets}/group-joinList-get/response-fields.adoc[]
+
 === 그룹 가입 신청 내역 처리
 ==== HTTP Request
 include::{snippets}/group-JoinList-approved/http-request.adoc[]

--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -7,3 +7,13 @@ include::{snippets}/user-profile/http-request.adoc[]
 ==== HTTP Response
 include::{snippets}/user-profile/http-response.adoc[]
 include::{snippets}/user-profile/response-fields.adoc[]
+
+
+=== 유저 닉네임 변경
+
+==== HTTP Request
+include::{snippets}/change-user-profile/http-request.adoc[]
+include::{snippets}/change-user-profile/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/change-user-profile/http-response.adoc[]

--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -1,0 +1,9 @@
+[[user-profile]]
+=== 유저 프로필 조회
+
+==== HTTP Request
+include::{snippets}/user-profile/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/user-profile/http-response.adoc[]
+include::{snippets}/user-profile/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -24,3 +24,8 @@ include::api/token/token.adoc[]
 == Group API
 
 include::api/group/group.adoc[]
+
+[[User-API]]
+== User API
+
+include::api/user/user.adoc[]

--- a/src/main/java/seondays/shareticon/group/Group.java
+++ b/src/main/java/seondays/shareticon/group/Group.java
@@ -17,6 +17,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import seondays.shareticon.group.dto.PendingMemberResponse;
 import seondays.shareticon.userGroup.UserGroup;
 import seondays.shareticon.utils.BaseEntity;
 import seondays.shareticon.user.User;
@@ -38,8 +39,28 @@ public class Group extends BaseEntity {
     @Column(unique = true)
     private String inviteCode;
     private String title;
+    @Builder.Default
     @OneToMany(mappedBy = "group", fetch = FetchType.LAZY)
     private List<UserGroup> userGroups = new ArrayList<>();
+
+    public List<PendingMemberResponse> getPendingMemberResponses() {
+        return this.userGroups.stream()
+                .filter(userGroup -> userGroup.getJoinStatus() == JoinStatus.PENDING)
+                .map(userGroup -> PendingMemberResponse.from(userGroup.getUser()))
+                .toList();
+    }
+
+    public String getGroupAlias(Long userId) {
+        return this.userGroups.stream()
+                .filter(userGroup -> userGroup.getUser().getId().equals(userId))
+                .map(UserGroup::getGroupTitleAlias)
+                .findFirst()
+                .orElse(title);
+    }
+
+    public void setUserGroups(List<UserGroup> userGroups) {
+        this.userGroups = userGroups;
+    }
 
     public static Group createNewGroup(User leaderUser, String inviteCode, String title) {
         return Group.builder()

--- a/src/main/java/seondays/shareticon/group/Group.java
+++ b/src/main/java/seondays/shareticon/group/Group.java
@@ -58,15 +58,16 @@ public class Group extends BaseEntity {
                 .orElse(title);
     }
 
-    public void setUserGroups(List<UserGroup> userGroups) {
-        this.userGroups = userGroups;
-    }
-
     public static Group createNewGroup(User leaderUser, String inviteCode, String title) {
         return Group.builder()
                 .leaderUser(leaderUser)
                 .inviteCode(inviteCode)
                 .title(title)
                 .build();
+    }
+
+    public static Group WithUserGroup(Group group, List<UserGroup> userGroups) {
+        group.userGroups = userGroups;
+        return group;
     }
 }

--- a/src/main/java/seondays/shareticon/group/GroupController.java
+++ b/src/main/java/seondays/shareticon/group/GroupController.java
@@ -63,7 +63,7 @@ public class GroupController {
     public ResponseEntity<List<ApplyToJoinResponse>> getAllApplyToJoinList(
             @AuthenticationPrincipal CustomOAuth2User userDetails) {
         Long userId = userDetails.getId();
-        List<ApplyToJoinResponse> responseList = groupService.getAllApplyToJoinList(userId);
+        List<ApplyToJoinResponse> responseList = groupService.getAllGroupPendingUserList(userId);
         return ResponseEntity.ok().body(responseList);
     }
 

--- a/src/main/java/seondays/shareticon/group/GroupRepository.java
+++ b/src/main/java/seondays/shareticon/group/GroupRepository.java
@@ -1,10 +1,23 @@
 package seondays.shareticon.group;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface GroupRepository extends JpaRepository<Group, Long> {
+
     Optional<Group> findByInviteCode(String inviteCode);
 
     boolean existsByInviteCode(String inviteCode);
+
+    // distinct를 통해 Group의 중복을 제거하고 엔티티를 올바르게 매핑하도록 명시적으로 지시한다
+    @Query("""
+            select distinct g
+            from Group g
+            join fetch g.userGroups ug
+            join fetch ug.user
+            where g.leaderUser.id = :leaderId
+            """)
+    List<Group> findAllByLeaderId(Long leaderId);
 }

--- a/src/main/java/seondays/shareticon/group/GroupService.java
+++ b/src/main/java/seondays/shareticon/group/GroupService.java
@@ -1,9 +1,5 @@
 package seondays.shareticon.group;
 
-import static seondays.shareticon.group.JoinStatus.JOINED;
-import static seondays.shareticon.group.JoinStatus.PENDING;
-import static seondays.shareticon.group.JoinStatus.REJECTED;
-
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +7,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import seondays.shareticon.exception.AlreadyAppliedToGroupException;
 import seondays.shareticon.exception.GroupCreateException;
 import seondays.shareticon.exception.GroupNotFoundException;
 import seondays.shareticon.exception.GroupUserNotFoundException;
-import seondays.shareticon.exception.InvalidAcceptGroupJoinApplyException;
-import seondays.shareticon.exception.InvalidJoinGroupException;
 import seondays.shareticon.exception.UserNotFoundException;
 import seondays.shareticon.group.dto.ApplyToJoinRequest;
 import seondays.shareticon.group.dto.ApplyToJoinResponse;
@@ -93,13 +86,13 @@ public class GroupService {
         userGroupRepository.save(userGroup);
     }
 
-    public List<ApplyToJoinResponse> getAllApplyToJoinList(Long leaderUserId) {
-        User leaderUser = userRepository.findById(leaderUserId)
-                .orElseThrow(UserNotFoundException::new);
+    public List<ApplyToJoinResponse> getAllGroupPendingUserList(Long leaderUserId) {
+        groupValidator.validateExistTargetUser(leaderUserId);
 
-        return userGroupRepository.findByLeaderAndJoinStatus(leaderUser.getId(), PENDING)
-                .stream()
-                .map(ApplyToJoinResponse::of)
+        List<Group> allGroupByLeaderUserId = groupRepository.findAllByLeaderId(leaderUserId);
+        return allGroupByLeaderUserId.stream()
+                .map(group -> ApplyToJoinResponse.of(group.getId(),
+                        group.getGroupAlias(leaderUserId), group.getPendingMemberResponses()))
                 .toList();
     }
 

--- a/src/main/java/seondays/shareticon/group/GroupValidator.java
+++ b/src/main/java/seondays/shareticon/group/GroupValidator.java
@@ -27,7 +27,7 @@ public class GroupValidator {
         validateExistTargetUser(request.targetUserId());
     }
 
-    private void validateExistTargetUser(Long targetUserId) {
+    public void validateExistTargetUser(Long targetUserId) {
         if (!userRepository.existsById(targetUserId)) {
             throw new UserNotFoundException();
         }

--- a/src/main/java/seondays/shareticon/group/dto/ApplyToJoinResponse.java
+++ b/src/main/java/seondays/shareticon/group/dto/ApplyToJoinResponse.java
@@ -1,16 +1,13 @@
 package seondays.shareticon.group.dto;
 
-import seondays.shareticon.group.Group;
-import seondays.shareticon.user.User;
-import seondays.shareticon.userGroup.UserGroup;
+import java.util.List;
 
-public record ApplyToJoinResponse(Long applyUserId,
-                                  String pendingUserName,
-                                  Long targetGroupId) {
+public record ApplyToJoinResponse(Long targetGroupId,
+                                  String leaderGroupAlias,
+                                  List<PendingMemberResponse> pendingMembers) {
 
-    public static ApplyToJoinResponse of(UserGroup userGroup) {
-        User user = userGroup.getUser();
-        Group group = userGroup.getGroup();
-        return new ApplyToJoinResponse(user.getId(), user.getNickname(), group.getId());
+    public static ApplyToJoinResponse of(Long targetGroupId, String leaderGroupAlias,
+            List<PendingMemberResponse> pendingMembers) {
+        return new ApplyToJoinResponse(targetGroupId, leaderGroupAlias, pendingMembers);
     }
 }

--- a/src/main/java/seondays/shareticon/group/dto/PendingMemberResponse.java
+++ b/src/main/java/seondays/shareticon/group/dto/PendingMemberResponse.java
@@ -1,0 +1,17 @@
+package seondays.shareticon.group.dto;
+
+import lombok.Builder;
+import seondays.shareticon.user.User;
+
+@Builder
+public record PendingMemberResponse(Long applyUserId,
+                                    String applyUserNickname) {
+
+    public static PendingMemberResponse of(Long applyUserId, String applyUserNickname) {
+        return new PendingMemberResponse(applyUserId, applyUserNickname);
+    }
+
+    public static PendingMemberResponse from(User user) {
+        return new PendingMemberResponse(user.getId(), user.getNickname());
+    }
+}

--- a/src/main/java/seondays/shareticon/login/provider/KakaoUser.java
+++ b/src/main/java/seondays/shareticon/login/provider/KakaoUser.java
@@ -25,16 +25,24 @@ public class KakaoUser implements OAuth2Provider {
     }
 
     @Override
+    public String getEmail() {
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+        return account.get("email").toString();
+    }
+
+    @Override
     public UserRole getRole() {
         return UserRole.ROLE_USER;
     }
 
     @Override
     public User toEntity() {
+        getEmail();
         return User.builder()
                 .nickname(getNickName())
                 .oauth2Id(getProviderId())
                 .oauth2Type(OAuth2Type.KAKAO)
+                .email(getEmail())
                 .role(getRole())
                 .build();
     }

--- a/src/main/java/seondays/shareticon/login/provider/OAuth2Provider.java
+++ b/src/main/java/seondays/shareticon/login/provider/OAuth2Provider.java
@@ -7,6 +7,7 @@ public interface OAuth2Provider {
 
     String getProviderId();
     String getNickName();
+    String getEmail();
     UserRole getRole();
     User toEntity();
 }

--- a/src/main/java/seondays/shareticon/user/User.java
+++ b/src/main/java/seondays/shareticon/user/User.java
@@ -33,4 +33,8 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserRole role;
     private String email;
+
+    public void changeNickname(String newNickname) {
+        nickname = newNickname;
+    }
 }

--- a/src/main/java/seondays/shareticon/user/User.java
+++ b/src/main/java/seondays/shareticon/user/User.java
@@ -32,4 +32,5 @@ public class User extends BaseEntity {
     private String oauth2Id;
     @Enumerated(EnumType.STRING)
     private UserRole role;
+    private String email;
 }

--- a/src/main/java/seondays/shareticon/user/UserController.java
+++ b/src/main/java/seondays/shareticon/user/UserController.java
@@ -1,12 +1,17 @@
 package seondays.shareticon.user;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import seondays.shareticon.login.CustomOAuth2User;
+import seondays.shareticon.user.dto.UserProfileChangeRequest;
 import seondays.shareticon.user.dto.UserProfileResponse;
 
 @RestController
@@ -23,5 +28,14 @@ public class UserController {
         UserProfileResponse result = userService.getUserProfile(userId);
 
         return ResponseEntity.ok(result);
+    }
+
+    @PatchMapping
+    public ResponseEntity<Void> changeUserProfile(
+            @AuthenticationPrincipal CustomOAuth2User userDetails,
+            @RequestBody @Valid UserProfileChangeRequest request) {
+        Long userId = userDetails.getId();
+        userService.changeUserProfile(userId, request);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/seondays/shareticon/user/UserController.java
+++ b/src/main/java/seondays/shareticon/user/UserController.java
@@ -1,0 +1,27 @@
+package seondays.shareticon.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import seondays.shareticon.login.CustomOAuth2User;
+import seondays.shareticon.user.dto.UserProfileResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/profile")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    public ResponseEntity<UserProfileResponse> getUserProfile(
+            @AuthenticationPrincipal CustomOAuth2User userDetails) {
+        Long userId = userDetails.getId();
+        UserProfileResponse result = userService.getUserProfile(userId);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/seondays/shareticon/user/UserService.java
+++ b/src/main/java/seondays/shareticon/user/UserService.java
@@ -2,13 +2,16 @@ package seondays.shareticon.user;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import seondays.shareticon.exception.UserNotFoundException;
+import seondays.shareticon.user.dto.UserProfileChangeRequest;
 import seondays.shareticon.user.dto.UserProfileResponse;
 import seondays.shareticon.userGroup.UserGroupRepository;
 import seondays.shareticon.voucher.VoucherRepository;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 
     private final UserRepository userRepository;
@@ -23,5 +26,13 @@ public class UserService {
         Long ownedVoucherCount = voucherRepository.countByUserId(userId);
 
         return UserProfileResponse.of(user, joinGroupCount, ownedVoucherCount);
+    }
+
+    @Transactional
+    public void changeUserProfile(Long userId, UserProfileChangeRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        String newNickname = request.newNickname();
+
+        user.changeNickname(newNickname);
     }
 }

--- a/src/main/java/seondays/shareticon/user/UserService.java
+++ b/src/main/java/seondays/shareticon/user/UserService.java
@@ -17,6 +17,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserGroupRepository userGroupRepository;
     private final VoucherRepository voucherRepository;
+    private final UserValidator userValidator;
 
     public UserProfileResponse getUserProfile(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
@@ -32,6 +33,8 @@ public class UserService {
     public void changeUserProfile(Long userId, UserProfileChangeRequest request) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         String newNickname = request.newNickname();
+
+        userValidator.validateUserProfile(newNickname);
 
         user.changeNickname(newNickname);
     }

--- a/src/main/java/seondays/shareticon/user/UserService.java
+++ b/src/main/java/seondays/shareticon/user/UserService.java
@@ -1,0 +1,27 @@
+package seondays.shareticon.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import seondays.shareticon.exception.UserNotFoundException;
+import seondays.shareticon.user.dto.UserProfileResponse;
+import seondays.shareticon.userGroup.UserGroupRepository;
+import seondays.shareticon.voucher.VoucherRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final UserGroupRepository userGroupRepository;
+    private final VoucherRepository voucherRepository;
+
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        Long joinGroupCount = userGroupRepository.countByUserId(userId);
+
+        Long ownedVoucherCount = voucherRepository.countByUserId(userId);
+
+        return UserProfileResponse.of(user, joinGroupCount, ownedVoucherCount);
+    }
+}

--- a/src/main/java/seondays/shareticon/user/UserValidator.java
+++ b/src/main/java/seondays/shareticon/user/UserValidator.java
@@ -1,0 +1,13 @@
+package seondays.shareticon.user;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserValidator {
+
+    public void validateUserProfile(String userNickname) {
+        if (userNickname == null || userNickname.isEmpty()) {
+            throw new IllegalArgumentException("닉네임은 비어 있을 수 없습니다");
+        }
+    }
+}

--- a/src/main/java/seondays/shareticon/user/UserValidator.java
+++ b/src/main/java/seondays/shareticon/user/UserValidator.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 public class UserValidator {
 
     public void validateUserProfile(String userNickname) {
-        if (userNickname == null || userNickname.isEmpty()) {
+        if (userNickname == null || userNickname.trim().isEmpty()) {
             throw new IllegalArgumentException("닉네임은 비어 있을 수 없습니다");
         }
     }

--- a/src/main/java/seondays/shareticon/user/dto/UserProfileChangeRequest.java
+++ b/src/main/java/seondays/shareticon/user/dto/UserProfileChangeRequest.java
@@ -1,0 +1,10 @@
+package seondays.shareticon.user.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Builder;
+
+@Builder
+public record UserProfileChangeRequest(
+        @NotEmpty(message = "변경할 닉네임을 포함해야 합니다") String newNickname) {
+
+}

--- a/src/main/java/seondays/shareticon/user/dto/UserProfileResponse.java
+++ b/src/main/java/seondays/shareticon/user/dto/UserProfileResponse.java
@@ -1,0 +1,20 @@
+package seondays.shareticon.user.dto;
+
+import lombok.Builder;
+import seondays.shareticon.user.User;
+
+@Builder
+public record UserProfileResponse(String nickName,
+                                  String email,
+                                  Long joinGroupCount,
+                                  Long ownedVoucherCount) {
+
+    public static UserProfileResponse of(User user, Long joinGroupCount, Long ownedVoucherCount) {
+        return UserProfileResponse.builder()
+                .nickName(user.getNickname())
+                .email(user.getEmail())
+                .joinGroupCount(joinGroupCount)
+                .ownedVoucherCount(ownedVoucherCount).build();
+    }
+
+}

--- a/src/main/java/seondays/shareticon/userGroup/UserGroupRepository.java
+++ b/src/main/java/seondays/shareticon/userGroup/UserGroupRepository.java
@@ -14,7 +14,7 @@ public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
 
     boolean existsByUserIdAndGroupId(Long userId, Long groupId);
 
-    List<UserGroup> findAllByUserId(Long userId);
+    Long countByUserId(Long userId);
 
     Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId);
 

--- a/src/main/java/seondays/shareticon/voucher/VoucherRepository.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherRepository.java
@@ -21,4 +21,6 @@ public interface VoucherRepository extends JpaRepository<Voucher, Long> {
     Slice<Voucher> findAllPageWithCursorByDesc(@Param("groupId") Long groupId,
             @Param("voucherStatuses") List<VoucherStatus> voucherStatuses,
             @Param("cursorId") Long cursorId, Pageable pageable);
+
+    Long countByUserId(Long userId);
 }

--- a/src/test/java/seondays/shareticon/api/config/ControllerTestSupport.java
+++ b/src/test/java/seondays/shareticon/api/config/ControllerTestSupport.java
@@ -10,13 +10,16 @@ import seondays.shareticon.group.GroupService;
 import seondays.shareticon.login.CustomOAuth2User;
 import seondays.shareticon.login.token.TokenController;
 import seondays.shareticon.login.token.TokenService;
+import seondays.shareticon.user.UserController;
+import seondays.shareticon.user.UserService;
 import seondays.shareticon.voucher.VoucherController;
 import seondays.shareticon.voucher.VoucherService;
 
 @WebMvcTest(controllers = {
         VoucherController.class,
         GroupController.class,
-        TokenController.class})
+        TokenController.class,
+        UserController.class})
 @Import({TestSecurityConfig.class, TestValidatorConfig.class})
 public abstract class ControllerTestSupport {
 
@@ -28,6 +31,9 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected TokenService tokenService;
+
+    @MockitoBean
+    protected UserService userService;
 
     @Autowired
     protected MockMvc mockMvc;

--- a/src/test/java/seondays/shareticon/api/config/TestSecurityConfig.java
+++ b/src/test/java/seondays/shareticon/api/config/TestSecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.LogoutConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -20,6 +21,7 @@ public class TestSecurityConfig {
                         .permitAll()
                         .anyRequest().authenticated());
 
+        http.csrf(AbstractHttpConfigurer::disable);
         http.logout(LogoutConfigurer::disable);
 
         // 로그인하지 않은 요청을 가정하는 경우, 익명 객체가 사용되므로 이 때도 401을 반환해주도록 상황을 설정하여 프로덕션 코드 동작과 일치시킴

--- a/src/test/java/seondays/shareticon/api/group/GroupControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupControllerTest.java
@@ -26,6 +26,7 @@ import seondays.shareticon.group.dto.ChangeGroupTitleAliasResponse;
 import seondays.shareticon.group.dto.CreateGroupRequest;
 import seondays.shareticon.group.dto.GroupListResponse;
 import seondays.shareticon.group.dto.GroupResponse;
+import seondays.shareticon.group.dto.PendingMemberResponse;
 import seondays.shareticon.login.CustomOAuth2User;
 import seondays.shareticon.user.dto.UserOAuth2Dto;
 
@@ -130,13 +131,16 @@ public class GroupControllerTest extends ControllerTestSupport {
     @DisplayName("유저가 확인할 수 있는 가입 신청 리스트를 조회한다")
     void getAllApplyToJoinList() throws Exception {
         //given
-        Long userId = mockUser.getId();
-        String userName = mockUser.getName();
-        ApplyToJoinResponse response1 = new ApplyToJoinResponse(userId, userName, 1L);
-        ApplyToJoinResponse response2 = new ApplyToJoinResponse(userId, userName, 2L);
-        List<ApplyToJoinResponse> responseList = List.of(response1, response2);
+        Long userId = 1L;
+        String userName = "가입신청한 유저";
 
-        when(groupService.getAllApplyToJoinList(any(Long.class))).thenReturn(responseList);
+        Long groupId = 1L;
+        String groupAlias = "리더의 그룹 별칭";
+
+        ApplyToJoinResponse response = new ApplyToJoinResponse(groupId, groupAlias, List.of(
+                PendingMemberResponse.of(userId, userName)));
+
+        when(groupService.getAllGroupPendingUserList(any(Long.class))).thenReturn(List.of(response));
 
         //when //then
         mockMvc.perform(
@@ -147,7 +151,10 @@ public class GroupControllerTest extends ControllerTestSupport {
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$.length()").value(2));
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].targetGroupId").value(groupId))
+                .andExpect(jsonPath("$[0].leaderGroupAlias").value(groupAlias))
+                .andExpect(jsonPath("$[0].pendingMembers").isArray());
     }
 
     @Test

--- a/src/test/java/seondays/shareticon/api/group/GroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupRepositoryTest.java
@@ -3,6 +3,7 @@ package seondays.shareticon.api.group;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,12 +11,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import seondays.shareticon.api.config.RepositoryTestSupport;
 import seondays.shareticon.group.Group;
 import seondays.shareticon.group.GroupRepository;
+import seondays.shareticon.user.User;
+import seondays.shareticon.user.UserRepository;
+import seondays.shareticon.userGroup.UserGroup;
+import seondays.shareticon.userGroup.UserGroupRepository;
 
 public class GroupRepositoryTest extends RepositoryTestSupport {
 
     @Autowired
     private GroupRepository groupRepository;
-    
+
+    @Autowired
+    private UserGroupRepository userGroupRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
     @Test
     @DisplayName("특정 초대 코드를 가진 그룹을 조회한다")
     void findByInviteCode() {
@@ -104,6 +115,53 @@ public class GroupRepositoryTest extends RepositoryTestSupport {
         LocalDateTime now = LocalDateTime.now();
         assertThat(result.get().getCreatedDateTime()).isBeforeOrEqualTo(now);
         assertThat(result.get().getModifiedDateTime()).isBeforeOrEqualTo(now);
+
+    }
+
+    @Test
+    @DisplayName("유저가 리더를 맡고 있는 그룹을 전부 조회하는 경우, 해당 그룹에 가입된 유저들의 정보인 UserGroup이 함께 조회된다.")
+    void findAllByLeaderId() {
+        //given
+        User leader = User.builder().build();
+        userRepository.save(leader);
+
+        Group group1 = Group.createNewGroup(leader, "test", "그룹1");
+        Group group2 = Group.createNewGroup(leader, "test2", "그룹2");
+        groupRepository.saveAll(List.of(group1, group2));
+
+        UserGroup leaderUserGroup1 = UserGroup.createLeaderUserGroup(leader, group1);
+        UserGroup leaderUserGroup2 = UserGroup.createLeaderUserGroup(leader, group2);
+        userGroupRepository.saveAll(List.of(leaderUserGroup1, leaderUserGroup2));
+
+        //when
+        List<Group> result = groupRepository.findAllByLeaderId(leader.getId());
+
+        //then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsExactlyInAnyOrder(group1, group2);
+
+        for (Group g : result) {
+            assertThat(g.getUserGroups()).isNotNull();
+            for (UserGroup ug : g.getUserGroups()) {
+                assertThat(ug.getUser()).isNotNull();
+                assertThat(ug.getGroup()).isNotNull();
+            }
+        }
+
+    }
+
+    @Test
+    @DisplayName("유저가 리더를 맡고 있는 그룹이 없다면 빈 리스트를 조회한다")
+    void findAllByNoLeader() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        //when
+        List<Group> result = groupRepository.findAllByLeaderId(user.getId());
+
+        //then
+        assertThat(result).isEmpty();
 
     }
 

--- a/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
@@ -39,6 +39,7 @@ import seondays.shareticon.group.dto.ChangeGroupTitleAliasResponse;
 import seondays.shareticon.group.dto.CreateGroupRequest;
 import seondays.shareticon.group.dto.GroupListResponse;
 import seondays.shareticon.group.dto.GroupResponse;
+import seondays.shareticon.group.dto.PendingMemberResponse;
 import seondays.shareticon.user.User;
 import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.userGroup.UserGroup;
@@ -162,8 +163,10 @@ public class GroupServiceTest extends IntegrationTestSupport {
         Group group2 = Group.builder().title(group2Title).build();
         groupRepository.saveAll(List.of(group1, group2));
 
-        UserGroup userGroup1 = UserGroup.builder().user(user).group(group1).groupTitleAlias(group1.getTitle()).build();
-        UserGroup userGroup2 = UserGroup.builder().user(user).group(group2).groupTitleAlias(group2.getTitle()).build();
+        UserGroup userGroup1 = UserGroup.builder().user(user).group(group1)
+                .groupTitleAlias(group1.getTitle()).build();
+        UserGroup userGroup2 = UserGroup.builder().user(user).group(group2)
+                .groupTitleAlias(group2.getTitle()).build();
         userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
 
         //when
@@ -172,7 +175,8 @@ public class GroupServiceTest extends IntegrationTestSupport {
         //then
         assertThat(responseList).hasSize(2);
         assertThat(responseList).extracting("groupId", "groupTitleAlias", "memberCount")
-                .contains(tuple(group1.getId(), group1Title, 1), tuple(group2.getId(), group2Title, 1));
+                .contains(tuple(group1.getId(), group1Title, 1),
+                        tuple(group2.getId(), group2Title, 1));
     }
 
     @Test
@@ -327,28 +331,46 @@ public class GroupServiceTest extends IntegrationTestSupport {
     @DisplayName("리더에게 들어온 그룹 신청 내역 목록을 조회한다")
     void getAllApplyToJoinList() {
         //given
+        String user1Nickname = "1번 유저";
+        String user2Nickname = "2번 유저";
+
         User leaderUser = User.builder().build();
-        User pendingUser = User.builder().build();
-        userRepository.save(leaderUser);
-        userRepository.save(pendingUser);
+        User pendingUser1 = User.builder().nickname(user1Nickname).build();
+        User pendingUser2 = User.builder().nickname(user2Nickname).build();
+        userRepository.saveAll(List.of(leaderUser, pendingUser1, pendingUser2));
 
         Group group = Group.builder().leaderUser(leaderUser).build();
-        groupRepository.save(group);
+        groupRepository.saveAll(List.of(group));
 
-        UserGroup userGroup1 = UserGroup.builder().user(leaderUser).group(group)
-                .joinStatus(JoinStatus.JOINED).build();
-        UserGroup userGroup2 = UserGroup.builder().user(pendingUser).group(group)
+        String leaderAlias1 = "첫번째 그룹";
+
+        UserGroup userGroup1 = UserGroup.builder().user(leaderUser).groupTitleAlias(leaderAlias1)
+                .group(group).joinStatus(JoinStatus.JOINED).build();
+        UserGroup userGroup2 = UserGroup.builder().user(pendingUser1).group(group)
                 .joinStatus(JoinStatus.PENDING).build();
-        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+        UserGroup userGroup3 = UserGroup.builder().user(pendingUser2).group(group)
+                .joinStatus(JoinStatus.PENDING).build();
+
+        userGroupRepository.saveAll(
+                List.of(userGroup1, userGroup2, userGroup3));
+
+        group.setUserGroups(List.of(userGroup1, userGroup2, userGroup3));
 
         //when
-        List<ApplyToJoinResponse> result = groupService.getAllApplyToJoinList(
+        List<ApplyToJoinResponse> result = groupService.getAllGroupPendingUserList(
                 leaderUser.getId());
 
         //then
+        PendingMemberResponse expectPendingUserResult1 = PendingMemberResponse.of(pendingUser1.getId(),
+                user1Nickname);
+        PendingMemberResponse expectPendingUserResult2 = PendingMemberResponse.of(pendingUser2.getId(),
+                user2Nickname);
+
+        ApplyToJoinResponse expectResult = ApplyToJoinResponse.of(group.getId(), leaderAlias1,
+                List.of(expectPendingUserResult1, expectPendingUserResult2));
+
         assertThat(result).hasSize(1)
-                .extracting("applyUserId", "targetGroupId")
-                .contains(tuple(pendingUser.getId(), group.getId()));
+                .contains(expectResult);
     }
 
     @Test
@@ -370,7 +392,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
         userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
 
         //when
-        List<ApplyToJoinResponse> result = groupService.getAllApplyToJoinList(
+        List<ApplyToJoinResponse> result = groupService.getAllGroupPendingUserList(
                 leaderUser.getId());
 
         //then
@@ -384,7 +406,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
         User user = User.builder().id(1L).build();
 
         //when //then
-        assertThatThrownBy(() -> groupService.getAllApplyToJoinList(user.getId()))
+        assertThatThrownBy(() -> groupService.getAllGroupPendingUserList(user.getId()))
                 .isInstanceOf(UserNotFoundException.class);
     }
 

--- a/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
@@ -354,7 +354,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
         userGroupRepository.saveAll(
                 List.of(userGroup1, userGroup2, userGroup3));
 
-        group.setUserGroups(List.of(userGroup1, userGroup2, userGroup3));
+        Group.WithUserGroup(group, List.of(userGroup1, userGroup2, userGroup3));
 
         //when
         List<ApplyToJoinResponse> result = groupService.getAllGroupPendingUserList(

--- a/src/test/java/seondays/shareticon/api/user/UserControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/user/UserControllerTest.java
@@ -1,0 +1,57 @@
+package seondays.shareticon.api.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import seondays.shareticon.api.config.ControllerTestSupport;
+import seondays.shareticon.login.CustomOAuth2User;
+import seondays.shareticon.user.dto.UserOAuth2Dto;
+import seondays.shareticon.user.dto.UserProfileResponse;
+
+public class UserControllerTest extends ControllerTestSupport {
+
+    @BeforeEach
+    void setup() {
+        mockUser = new CustomOAuth2User(new UserOAuth2Dto(1L, "user", "ROLE_USER"));
+    }
+
+    @Test
+    @DisplayName("유저 프로필 조회 시 결과에는 유저 닉네임, 유저 이메일, 유저가 가입한 그룹 카운트, 유저가 등록한 기프티콘 카운트가 포함된다")
+    void getUserProfile() throws Exception {
+        //given
+        String nickname = "닉네임";
+        String email = "test@test";
+        Long joinGroupCount = 1L;
+        Long ownedVoucherCount = 2L;
+
+        UserProfileResponse mockResponse = UserProfileResponse.builder().nickName(nickname)
+                .email(email).joinGroupCount(joinGroupCount).ownedVoucherCount(ownedVoucherCount).build();
+
+        //when
+        when(userService.getUserProfile(any(Long.class))).thenReturn(mockResponse);
+
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/profile")
+                        .with(csrf())
+                        .with(oauth2Login().oauth2User(mockUser))
+        )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.nickName").value(nickname))
+                .andExpect(jsonPath("$.email").value(email))
+                .andExpect(jsonPath("$.joinGroupCount").value(joinGroupCount))
+                .andExpect(jsonPath("$.ownedVoucherCount").value(ownedVoucherCount));
+
+    }
+
+}

--- a/src/test/java/seondays/shareticon/api/user/UserControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/user/UserControllerTest.java
@@ -1,23 +1,31 @@
 package seondays.shareticon.api.user;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import seondays.shareticon.api.config.ControllerTestSupport;
 import seondays.shareticon.login.CustomOAuth2User;
 import seondays.shareticon.user.dto.UserOAuth2Dto;
+import seondays.shareticon.user.dto.UserProfileChangeRequest;
 import seondays.shareticon.user.dto.UserProfileResponse;
 
 public class UserControllerTest extends ControllerTestSupport {
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setup() {
@@ -34,23 +42,79 @@ public class UserControllerTest extends ControllerTestSupport {
         Long ownedVoucherCount = 2L;
 
         UserProfileResponse mockResponse = UserProfileResponse.builder().nickName(nickname)
-                .email(email).joinGroupCount(joinGroupCount).ownedVoucherCount(ownedVoucherCount).build();
+                .email(email).joinGroupCount(joinGroupCount).ownedVoucherCount(ownedVoucherCount)
+                .build();
 
         //when
         when(userService.getUserProfile(any(Long.class))).thenReturn(mockResponse);
 
         //then
         mockMvc.perform(
-                MockMvcRequestBuilders.get("/profile")
-                        .with(csrf())
-                        .with(oauth2Login().oauth2User(mockUser))
-        )
+                        MockMvcRequestBuilders.get("/profile")
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(jsonPath("$.nickName").value(nickname))
                 .andExpect(jsonPath("$.email").value(email))
                 .andExpect(jsonPath("$.joinGroupCount").value(joinGroupCount))
                 .andExpect(jsonPath("$.ownedVoucherCount").value(ownedVoucherCount));
+
+    }
+
+    @Test
+    @DisplayName("유효한 닉네임으로 유저 프로필을 변경한다")
+    void changeUserProfile() throws Exception {
+        //given
+        String newNickname = "새로운 닉네임";
+
+        UserProfileChangeRequest request = UserProfileChangeRequest
+                .builder()
+                .newNickname(newNickname)
+                .build();
+        String jsonRequest = objectMapper.writeValueAsString(request);
+
+        //when
+        doNothing().when(userService)
+                .changeUserProfile(any(Long.class), any(UserProfileChangeRequest.class));
+
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.patch("/profile")
+                        .with(oauth2Login().oauth2User(mockUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonRequest)
+        )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isNoContent());
+
+    }
+
+    @Test
+    @DisplayName("유저 프로필 변경 시 닉네임은 비어있을 수 없다")
+    void changeUserProfileWithoutNickname() throws Exception{
+        //given
+        String newNickname = "";
+
+        UserProfileChangeRequest request = UserProfileChangeRequest
+                .builder()
+                .newNickname(newNickname)
+                .build();
+        String jsonRequest = objectMapper.writeValueAsString(request);
+
+        //when
+        doNothing().when(userService)
+                .changeUserProfile(any(Long.class), any(UserProfileChangeRequest.class));
+
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.patch("/profile")
+                        .with(oauth2Login().oauth2User(mockUser))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonRequest)
+        )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isBadRequest());
 
     }
 

--- a/src/test/java/seondays/shareticon/api/user/UserServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/user/UserServiceTest.java
@@ -93,6 +93,25 @@ public class UserServiceTest extends IntegrationTestSupport {
 
     }
 
+    @Test
+    @DisplayName("유저 정보 변경 시 닉네임이 업데이트 된다")
+    void changeUserProfile() {
+        //given
+        String nickname = "닉네임";
+        String email = "test@test";
+        User user = User.builder().nickname(nickname).email(email).build();
+        userRepository.save(user);
+
+        String newNickname = "새로운 닉네임";
+
+        //when
+        user.changeNickname(newNickname);
+
+        //then
+        assertThat(user.getNickname()).isEqualTo(newNickname);
+
+    }
+
     private UserGroup linkUserWithGroup(User user, Group group) {
         UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
         userGroupRepository.save(userGroup);

--- a/src/test/java/seondays/shareticon/api/user/UserServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/user/UserServiceTest.java
@@ -1,0 +1,101 @@
+package seondays.shareticon.api.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import seondays.shareticon.api.config.IntegrationTestSupport;
+import seondays.shareticon.exception.UserNotFoundException;
+import seondays.shareticon.group.Group;
+import seondays.shareticon.group.GroupRepository;
+import seondays.shareticon.user.User;
+import seondays.shareticon.user.UserRepository;
+import seondays.shareticon.user.UserService;
+import seondays.shareticon.user.dto.UserProfileResponse;
+import seondays.shareticon.userGroup.UserGroup;
+import seondays.shareticon.userGroup.UserGroupRepository;
+import seondays.shareticon.voucher.Voucher;
+import seondays.shareticon.voucher.VoucherRepository;
+
+public class UserServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private UserGroupRepository userGroupRepository;
+
+    @Autowired
+    private VoucherRepository voucherRepository;
+
+    @AfterEach
+    void tearDown() {
+        userGroupRepository.deleteAllInBatch();
+        voucherRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+        groupRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("유저의 프로필 정보를 조회한다")
+    void getUserProfile() {
+        //given
+        String nickname = "닉네임";
+        String email = "test@test";
+        User user = User.builder().nickname(nickname).email(email).build();
+        userRepository.save(user);
+
+        Group group = Group.builder().build();
+        Group group2 = Group.builder().build();
+        Group group3 = Group.builder().build();
+        groupRepository.saveAll(List.of(group3, group2, group));
+
+        linkUserWithGroup(user, group);
+        linkUserWithGroup(user, group2);
+        linkUserWithGroup(user, group3);
+
+        Voucher voucher = Voucher.builder().user(user).group(group).build();
+        Voucher voucher2 = Voucher.builder().user(user).group(group).build();
+        voucherRepository.saveAll(List.of(voucher, voucher2));
+
+        //when
+        UserProfileResponse response = userService.getUserProfile(user.getId());
+
+        //then
+        assertThat(response.nickName()).isEqualTo(nickname);
+        assertThat(response.email()).isEqualTo(email);
+        assertThat(response.joinGroupCount()).isEqualTo(3);
+        assertThat(response.ownedVoucherCount()).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("유저 프로필 조회 시 해당하는 유저가 존재하지 않으면 예외가 발생한다")
+    void getUserProfileWithUserNoExist() {
+        //given
+        String nickname = "닉네임";
+        String email = "test@test";
+        User user = User.builder().id(1L).nickname(nickname).email(email).build();
+
+        //when //then
+        assertThatThrownBy(() -> userService.getUserProfile(user.getId())).isInstanceOf(
+                UserNotFoundException.class);
+
+    }
+
+    private UserGroup linkUserWithGroup(User user, Group group) {
+        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
+        userGroupRepository.save(userGroup);
+        return userGroup;
+    }
+}

--- a/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
@@ -187,4 +187,42 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         assertThat(result.get().getModifiedDateTime()).isBeforeOrEqualTo(now);
 
     }
+
+    @Test
+    @DisplayName("특정 유저가 가입되어 있는 전체 그룹의 수를 조회한다")
+    void getUserJoinGroupCount() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        Group group = Group.builder().build();
+        Group group2 = Group.builder().build();
+        groupRepository.saveAll(List.of(group, group2));
+
+        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
+        UserGroup userGroup2 = UserGroup.builder().user(user).group(group2).build();
+        userGroupRepository.saveAll(List.of(userGroup, userGroup2));
+
+        //when
+        Long result = userGroupRepository.countByUserId(user.getId());
+
+        //then
+        assertThat(result).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("특정 유저가 가입되어 있는 전체 그룹의 수가 0개여도 정상적으로 조회된다")
+    void getUserJoinGroupCountZero() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        //when
+        Long result = userGroupRepository.countByUserId(user.getId());
+
+        //then
+        assertThat(result).isZero();
+
+    }
 }

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Slice;
 import seondays.shareticon.api.config.RepositoryTestSupport;
 import seondays.shareticon.group.Group;
 import seondays.shareticon.group.GroupRepository;
+import seondays.shareticon.user.User;
+import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.voucher.Voucher;
 import seondays.shareticon.voucher.VoucherRepository;
 import seondays.shareticon.voucher.VoucherStatus;
@@ -24,6 +26,9 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
 
     @Autowired
     private VoucherRepository voucherRepository;
+
+    @Autowired
+    private UserRepository userRepository;
 
     @Test
     @DisplayName("전체 쿠폰의 첫번째 페이지를 조회한다")
@@ -187,10 +192,59 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         assertThat(resultPage.hasNext()).isFalse();
     }
 
+    @Test
+    @DisplayName("특정 유저가 등록한 모든 쿠폰의 개수를 조회한다")
+    void getAllVoucherByUser() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        Group group = Group.builder()
+                .build();
+        groupRepository.save(group);
+
+        Voucher voucher1 = createVoucherWithUser(group, VoucherStatus.AVAILABLE, user);
+        Voucher voucher2 = createVoucherWithUser(group, VoucherStatus.USED, user);
+        Voucher voucher3 = createVoucherWithUser(group, VoucherStatus.EXPIRED, user);
+        Voucher voucher4 = createVoucherWithUser(group, VoucherStatus.AVAILABLE, user);
+        Voucher voucher5 = createVoucherWithUser(group, VoucherStatus.EXPIRED, user);
+        voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
+
+        //when
+        Long result = voucherRepository.countByUserId(user.getId());
+
+        //then
+        assertThat(result).isEqualTo(5);
+
+    }
+
+    @Test
+    @DisplayName("특정 유저가 등록한 모든 쿠폰의 개수가 0개여도 정상적으로 조회된다")
+    void getAllVoucherByUserZero() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        //when
+        Long result = voucherRepository.countByUserId(user.getId());
+
+        //then
+        assertThat(result).isZero();
+
+    }
+
 
     private static Voucher createVoucher(Group group, VoucherStatus status) {
         return Voucher.builder()
                 .group(group)
+                .status(status)
+                .build();
+    }
+
+    private static Voucher createVoucherWithUser(Group group, VoucherStatus status, User user) {
+        return Voucher.builder()
+                .group(group)
+                .user(user)
                 .status(status)
                 .build();
     }

--- a/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
+++ b/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.validation.Validation;
 import jakarta.validation.ValidatorFactory;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.validation.Validator;
 import java.time.Clock;
 import java.time.Instant;
@@ -57,6 +58,12 @@ public abstract class RestDocsSupport {
 
     protected abstract Object initController();
 
+    protected RequestPostProcessor addBearerToken() {
+        return request -> {
+            request.addHeader("Authorization", "Bearer TOKEN_VALUE");
+            return request;
+        };
+    }
 
     private Validator validator(Clock clock) {
         ValidatorFactory factory = Validation.byDefaultProvider()

--- a/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
+++ b/src/test/java/seondays/shareticon/docs/RestDocsSupport.java
@@ -44,7 +44,11 @@ public abstract class RestDocsSupport {
         // setMessageConverters를 통해 mockMvc의 LocalDate 역직렬화를 위한 컨버터 추가
         // DTO 검증을 수행할 validator에서 우리가 지정한 clock 객체를 사용하도록 직접 설정
         this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
-                .apply(documentationConfiguration(provider))
+                .apply(documentationConfiguration(provider)
+                        .uris()
+                        .withScheme("https")
+                        .withHost("api.shareticon.site")
+                        .withPort(443))
                 .setCustomArgumentResolvers(new AuthenticationPrincipalArgumentResolver())
                 .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
                 .setValidator(validator(clock()))

--- a/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
@@ -69,7 +69,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
                         MockMvcRequestBuilders.post("/group")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(json)
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isCreated())
@@ -102,7 +102,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
         //when //then
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/group")
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -136,7 +136,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
                         MockMvcRequestBuilders.post("/group/join")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(json)
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isNoContent())
@@ -164,7 +164,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
         //when //then
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/group/join")
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -196,7 +196,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
                         MockMvcRequestBuilders.patch("/group/{groupId}/user/{userId}", 1L, userId)
                                 .queryParam("status", "APPROVED")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isNoContent())
@@ -234,7 +234,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
                         MockMvcRequestBuilders.patch("/group/{groupId}", groupId)
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(json)
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
@@ -20,6 +20,7 @@ import seondays.shareticon.group.dto.ChangeGroupTitleAliasResponse;
 import seondays.shareticon.group.dto.CreateGroupRequest;
 import seondays.shareticon.group.dto.GroupListResponse;
 import seondays.shareticon.group.dto.GroupResponse;
+import seondays.shareticon.group.dto.PendingMemberResponse;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -36,7 +37,6 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -153,13 +153,16 @@ public class GroupControllerDocsTest extends RestDocsSupport {
     @DisplayName("유저가 확인할 수 있는 가입 신청 리스트를 조회한다")
     void getAllApplyToJoinList() throws Exception {
         //given
-        Long userId = mockUser.getId();
-        String userName = mockUser.getName();
-        ApplyToJoinResponse response1 = new ApplyToJoinResponse(userId, userName, 1L);
-        ApplyToJoinResponse response2 = new ApplyToJoinResponse(userId, userName, 2L);
-        List<ApplyToJoinResponse> responseList = List.of(response1, response2);
+        Long userId = 1L;
+        String userName = "가입신청한 유저";
 
-        when(groupService.getAllApplyToJoinList(any(Long.class))).thenReturn(responseList);
+        Long groupId = 1L;
+        String groupAlias = "리더의 그룹 별칭";
+
+        ApplyToJoinResponse response = new ApplyToJoinResponse(groupId, groupAlias, List.of(
+                PendingMemberResponse.of(userId, userName)));
+
+        when(groupService.getAllGroupPendingUserList(any(Long.class))).thenReturn(List.of(response));
 
         //when //then
         mockMvc.perform(
@@ -169,19 +172,26 @@ public class GroupControllerDocsTest extends RestDocsSupport {
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$.length()").value(1))
+                .andExpect(jsonPath("$[0].targetGroupId").value(groupId))
+                .andExpect(jsonPath("$[0].leaderGroupAlias").value(groupAlias))
+                .andExpect(jsonPath("$[0].pendingMembers").isArray())
                 .andDo(document("group-joinList-get",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         responseFields(
                                 fieldWithPath("[]").type(JsonFieldType.ARRAY)
                                         .description("유저가 처리할 수 있는 그룹 가입 신청 리스트"),
-                                fieldWithPath("[].applyUserId").type(JsonFieldType.NUMBER)
-                                        .description("신청한 유저의 ID"),
-                                fieldWithPath("[].pendingUserName").type(JsonFieldType.STRING)
-                                        .description("신청한 유저의 닉네임"),
                                 fieldWithPath("[].targetGroupId").type(JsonFieldType.NUMBER)
-                                        .description("유저가 가입 신청한 그룹 ID")
+                                        .description("가입 신청이 들어온 그룹 ID"),
+                                fieldWithPath("[].leaderGroupAlias").type(JsonFieldType.STRING)
+                                        .description("리더가 설정한 가입 신청이 들어온 그룹의 별칭"),
+                                fieldWithPath("[].pendingMembers").type(JsonFieldType.ARRAY)
+                                        .description("가입을 신청한 유저의 리스트"),
+                                fieldWithPath("[].pendingMembers[].applyUserId").type(JsonFieldType.NUMBER)
+                                        .description("가입을 신청한 유저 ID"),
+                                fieldWithPath("[].pendingMembers[].applyUserNickname").type(JsonFieldType.STRING)
+                                        .description("가입을 신청한 유저의 닉네임")
                         )));
     }
 

--- a/src/test/java/seondays/shareticon/docs/token/TokenControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/token/TokenControllerDocsTest.java
@@ -12,7 +12,6 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
@@ -71,7 +70,6 @@ public class TokenControllerDocsTest extends RestDocsSupport {
                         MockMvcRequestBuilders.post("/logout")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .header(HttpHeaders.AUTHORIZATION, accessToken)
-                                .with(authentication(auth))
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())

--- a/src/test/java/seondays/shareticon/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/user/UserControllerDocsTest.java
@@ -1,0 +1,69 @@
+package seondays.shareticon.docs.user;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import seondays.shareticon.docs.RestDocsSupport;
+import seondays.shareticon.user.UserController;
+import seondays.shareticon.user.UserService;
+import seondays.shareticon.user.dto.UserProfileResponse;
+
+public class UserControllerDocsTest extends RestDocsSupport {
+
+    private final UserService userService = mock(UserService.class);
+
+    @Override
+    protected Object initController() {
+        return new UserController(userService);
+    }
+
+    @Test
+    @DisplayName("유저 프로필 조회 시 결과에는 유저 닉네임, 유저 이메일, 유저가 가입한 그룹 카운트, 유저가 등록한 기프티콘 카운트가 포함된다")
+    void getUserProfile() throws Exception {
+        //given
+        String nickname = "닉네임";
+        String email = "test@test";
+
+        UserProfileResponse mockResponse = UserProfileResponse.builder().nickName(nickname)
+                .email(email).joinGroupCount(1L).ownedVoucherCount(2L).build();
+
+        //when
+        when(userService.getUserProfile(any(Long.class))).thenReturn(mockResponse);
+
+        //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/profile")
+                                .with(addBearerToken())
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.nickName").value(nickname))
+                .andExpect(jsonPath("$.email").value(email))
+                .andExpect(jsonPath("$.joinGroupCount").value(1))
+                .andExpect(jsonPath("$.ownedVoucherCount").value(2))
+                .andDo(document("user-profile",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        responseFields(
+                                fieldWithPath("nickName").type(JsonFieldType.STRING).description("유저의 닉네임"),
+                                fieldWithPath("email").type(JsonFieldType.STRING).description("유저의 이메일"),
+                                fieldWithPath("joinGroupCount").type(JsonFieldType.NUMBER).description("유저가 가입되어 있는 그룹의 개수"),
+                                fieldWithPath("ownedVoucherCount").type(JsonFieldType.NUMBER).description("유저가 등록한 쿠폰의 총 개수")
+                        )));
+
+    }
+}

--- a/src/test/java/seondays/shareticon/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/user/UserControllerDocsTest.java
@@ -1,6 +1,7 @@
 package seondays.shareticon.docs.user;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -8,11 +9,14 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
@@ -20,6 +24,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import seondays.shareticon.docs.RestDocsSupport;
 import seondays.shareticon.user.UserController;
 import seondays.shareticon.user.UserService;
+import seondays.shareticon.user.dto.UserProfileChangeRequest;
 import seondays.shareticon.user.dto.UserProfileResponse;
 
 public class UserControllerDocsTest extends RestDocsSupport {
@@ -63,6 +68,40 @@ public class UserControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("유저의 이메일"),
                                 fieldWithPath("joinGroupCount").type(JsonFieldType.NUMBER).description("유저가 가입되어 있는 그룹의 개수"),
                                 fieldWithPath("ownedVoucherCount").type(JsonFieldType.NUMBER).description("유저가 등록한 쿠폰의 총 개수")
+                        )));
+
+    }
+
+    @Test
+    @DisplayName("유효한 닉네임으로 유저 프로필을 변경한다")
+    void changeUserProfile() throws Exception {
+        //given
+        String newNickname = "새로운 닉네임";
+
+        UserProfileChangeRequest request = UserProfileChangeRequest
+                .builder()
+                .newNickname(newNickname)
+                .build();
+        String jsonRequest = objectMapper.writeValueAsString(request);
+
+        //when
+        doNothing().when(userService)
+                .changeUserProfile(any(Long.class), any(UserProfileChangeRequest.class));
+
+        //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.patch("/profile")
+                                .with(addBearerToken())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(jsonRequest)
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isNoContent())
+                .andDo(document("change-user-profile",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("newNickname").type(JsonFieldType.STRING).description("유저가 새로 바꾸려는 닉네임")
                         )));
 
     }

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -17,7 +17,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.partWith
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
@@ -97,7 +96,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                 .file(imagePart)
                                 .file(requestPart)
                                 .contentType(MediaType.MULTIPART_FORM_DATA)
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isCreated())
@@ -150,7 +149,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                         MockMvcRequestBuilders.delete("/vouchers/group/{groupId}/voucher/{voucherId}",
                                         groupId, voucherId)
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -211,7 +210,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                         MockMvcRequestBuilders.get("/vouchers/{groupId}", groupId)
                                 .param("cursorId", cursorId.toString())
                                 .param("pageSize", String.valueOf(pageSize))
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
@@ -308,7 +307,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                         MockMvcRequestBuilders.patch("/vouchers/group/{groupId}/voucher/{voucherId}",
                                         groupId, voucherId)
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .with(authentication(auth))
+                                .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())


### PR DESCRIPTION
## 연관 이슈
close #29, #30

## 작업 내용
- 회원 정보 조회 API 추가
- 그룹 가입 신청 리스트 조회 Response 형식 변경, 이에 따른 로직 변경
- API 문서의 Host 헤더, Authentication 헤더 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 프로필 조회 및 닉네임 변경 API가 추가되었습니다.
  * 사용자 관련 REST API 문서가 새롭게 제공됩니다.
  * 그룹 가입 신청 내역 조회 기능이 그룹별 대기 멤버 목록을 포함하도록 개선되었습니다.

* **버그 수정**
  * 그룹 가입 신청 내역 조회 응답 구조가 개선되어, 대기 중인 멤버 목록을 그룹 단위로 확인할 수 있습니다.

* **문서화**
  * User API 및 그룹 가입 신청 관련 문서가 추가 및 개선되었습니다.
  * REST Docs 예시와 필드 설명이 보강되었습니다.

* **테스트**
  * 사용자 프로필 기능과 그룹 관련 기능에 대한 단위/통합/문서화 테스트가 추가 및 보완되었습니다.

* **기타**
  * 인증 테스트 방식 개선 및 CSRF 비활성화 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->