### PR TITLE
add voucher delete

### DIFF
--- a/src/main/java/seondays/shareticon/exception/ImageDeleteException.java
+++ b/src/main/java/seondays/shareticon/exception/ImageDeleteException.java
@@ -1,0 +1,8 @@
+package seondays.shareticon.exception;
+
+public class ImageDeleteException extends RuntimeException {
+
+    public ImageDeleteException() {
+        super("쿠폰 이미지 삭제가 실패했습니다");
+    }
+}

--- a/src/main/java/seondays/shareticon/group/Group.java
+++ b/src/main/java/seondays/shareticon/group/Group.java
@@ -34,7 +34,7 @@ public class Group extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "leader_user_id")
+    @JoinColumn(name = "leader_user_id", nullable = false)
     private User leaderUser;
     @Column(unique = true)
     private String inviteCode;

--- a/src/main/java/seondays/shareticon/group/GroupService.java
+++ b/src/main/java/seondays/shareticon/group/GroupService.java
@@ -66,7 +66,8 @@ public class GroupService {
     }
 
     public List<GroupListResponse> getAllGroupList(Long userId) {
-        return userGroupRepository.findGroupsWithMemberCountByUserId(userId)
+        return userGroupRepository.findGroupsWithMemberCountByUserIdAndStatus(
+                userId, JoinStatus.getStatusesForAcceptedGroupMembers())
                 .stream()
                 .toList();
     }

--- a/src/main/java/seondays/shareticon/group/JoinStatus.java
+++ b/src/main/java/seondays/shareticon/group/JoinStatus.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.group;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import seondays.shareticon.exception.AlreadyAppliedToGroupException;
 import seondays.shareticon.exception.InvalidJoinGroupException;
@@ -23,5 +24,9 @@ public enum JoinStatus {
         if (!this.equals(PENDING)) {
             throw new InvalidJoinGroupException();
         }
+    }
+
+    public static List<JoinStatus> getStatusesForAcceptedGroupMembers() {
+        return List.of(JOINED);
     }
 }

--- a/src/main/java/seondays/shareticon/group/dto/GroupListResponse.java
+++ b/src/main/java/seondays/shareticon/group/dto/GroupListResponse.java
@@ -2,7 +2,7 @@ package seondays.shareticon.group.dto;
 
 public record GroupListResponse(Long groupId,
                                 String groupTitleAlias,
-                                int memberCount) {
+                                Long memberCount) {
 
     public GroupListResponse {}
 }

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -7,10 +7,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import seondays.shareticon.exception.ImageDeleteException;
 import seondays.shareticon.exception.ImageUploadException;
 import seondays.shareticon.exception.PresignedUrlGenerationException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
@@ -68,6 +70,19 @@ public class ImageService {
             return generatedPresignedUrl.url().toString();
         } catch (Exception e) {
             throw new PresignedUrlGenerationException();
+        }
+    }
+
+    public void deleteImage(String key) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (Exception e) {
+            throw new ImageDeleteException();
         }
     }
 }

--- a/src/main/java/seondays/shareticon/user/dto/UserProfileResponse.java
+++ b/src/main/java/seondays/shareticon/user/dto/UserProfileResponse.java
@@ -4,13 +4,15 @@ import lombok.Builder;
 import seondays.shareticon.user.User;
 
 @Builder
-public record UserProfileResponse(String nickName,
+public record UserProfileResponse(Long userId,
+                                  String nickName,
                                   String email,
                                   Long joinGroupCount,
                                   Long ownedVoucherCount) {
 
     public static UserProfileResponse of(User user, Long joinGroupCount, Long ownedVoucherCount) {
         return UserProfileResponse.builder()
+                .userId(user.getId())
                 .nickName(user.getNickname())
                 .email(user.getEmail())
                 .joinGroupCount(joinGroupCount)

--- a/src/main/java/seondays/shareticon/userGroup/UserGroup.java
+++ b/src/main/java/seondays/shareticon/userGroup/UserGroup.java
@@ -38,11 +38,11 @@ public class UserGroup extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_id")
+    @JoinColumn(name = "group_id", nullable = false)
     private Group group;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/seondays/shareticon/userGroup/UserGroupRepository.java
+++ b/src/main/java/seondays/shareticon/userGroup/UserGroupRepository.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import seondays.shareticon.group.JoinStatus;
 import seondays.shareticon.group.dto.GroupListResponse;
@@ -31,11 +30,14 @@ public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
             SELECT new seondays.shareticon.group.dto.GroupListResponse(
                 g.id,
                 ug.groupTitleAlias,
-                SIZE(g.userGroups)
+                COUNT(ug2.id)
             )
             FROM UserGroup ug
             JOIN ug.group g
+            LEFT JOIN UserGroup ug2 ON ug2.group.id = g.id AND ug2.joinStatus IN :status
             WHERE ug.user.id = :userId
+            AND ug.joinStatus in :status
+            GROUP BY g.id, ug.groupTitleAlias
             """)
-    List<GroupListResponse> findGroupsWithMemberCountByUserId(Long userId);
+    List<GroupListResponse> findGroupsWithMemberCountByUserIdAndStatus(Long userId, List<JoinStatus> status);
 }

--- a/src/main/java/seondays/shareticon/voucher/Voucher.java
+++ b/src/main/java/seondays/shareticon/voucher/Voucher.java
@@ -36,10 +36,10 @@ public class Voucher extends BaseEntity {
     private String name;
     private LocalDate expiration;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_id")
+    @JoinColumn(name = "group_id", nullable = false)
     private Group group;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
     private String image;
     @Enumerated(value = EnumType.STRING)

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -85,10 +85,11 @@ public class VoucherService {
      */
     private Voucher createVoucherWithImage(User user, Group group, VoucherImage image, String name,
             LocalDate expiration) {
+        String imageUrl = imageService.uploadImage(image.getImageFile());
+
         Voucher voucher = Voucher.createAvailableStatus(user, group, name, expiration);
         voucherRepository.save(voucher);
 
-        String imageUrl = imageService.uploadImage(image.getImageFile());
         voucher.saveImage(imageUrl);
 
         return voucherRepository.save(voucher);
@@ -114,6 +115,8 @@ public class VoucherService {
         voucherValidator.validateVoucherDeletion(validationRequest);
 
         voucherRepository.delete(voucher);
+
+        imageService.deleteImage(voucher.getImage());
     }
 
     /**

--- a/src/main/java/seondays/shareticon/voucher/dto/VouchersResponse.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/VouchersResponse.java
@@ -7,6 +7,7 @@ import seondays.shareticon.voucher.VoucherStatus;
 public record VouchersResponse(Long id,
                                String presignedImage,
                                String name,
+                               Long registeredUserId,
                                LocalDate expiration,
                                VoucherStatus status) {
     public static VouchersResponse of(Voucher voucher, String presignedImage) {
@@ -14,6 +15,7 @@ public record VouchersResponse(Long id,
                 voucher.getId(),
                 presignedImage,
                 voucher.getName(),
+                voucher.getUser().getId(),
                 voucher.getExpiration(),
                 voucher.getStatus()
         );

--- a/src/test/java/seondays/shareticon/api/group/GroupControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupControllerTest.java
@@ -71,8 +71,8 @@ public class GroupControllerTest extends ControllerTestSupport {
     @DisplayName("유저의 모든 그룹 리스트를 조회한다")
     void getAllGroupList() throws Exception {
         //given
-        GroupListResponse response1 = new GroupListResponse(1L, "title1", 2);
-        GroupListResponse response2 = new GroupListResponse(2L, "title2", 2);
+        GroupListResponse response1 = new GroupListResponse(1L, "title1", 2L);
+        GroupListResponse response2 = new GroupListResponse(2L, "title2", 2L);
         List<GroupListResponse> responseList = List.of(response1, response2);
 
         when(groupService.getAllGroupList(any(Long.class))).thenReturn(responseList);

--- a/src/test/java/seondays/shareticon/api/group/GroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,7 +33,7 @@ public class GroupRepositoryTest extends RepositoryTestSupport {
     void findByInviteCode() {
         //given
         String inviteCode = "ABC";
-        Group group = Group.builder().inviteCode(inviteCode).build();
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         //when
@@ -49,7 +50,7 @@ public class GroupRepositoryTest extends RepositoryTestSupport {
     void findByNoExistInviteCode() {
         //given
         String inviteCode = "ABC";
-        Group group = Group.builder().inviteCode(inviteCode).build();
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         //when
@@ -66,7 +67,7 @@ public class GroupRepositoryTest extends RepositoryTestSupport {
     void existByInviteCode() {
         //given
         String inviteCode = "ABC";
-        Group group = Group.builder().inviteCode(inviteCode).build();
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         //when
@@ -82,7 +83,7 @@ public class GroupRepositoryTest extends RepositoryTestSupport {
     void noExistByInviteCode() {
         //given
         String inviteCode = "ABC";
-        Group group = Group.builder().inviteCode(inviteCode).build();
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         //when
@@ -99,7 +100,7 @@ public class GroupRepositoryTest extends RepositoryTestSupport {
     void auditingGroup() {
         // given
         String inviteCode = "ABC";
-        Group group = Group.builder().inviteCode(inviteCode).build();
+        Group group = createTestGroup(inviteCode);
 
         // when
         groupRepository.save(group);
@@ -163,6 +164,12 @@ public class GroupRepositoryTest extends RepositoryTestSupport {
         //then
         assertThat(result).isEmpty();
 
+    }
+
+    public Group createTestGroup(String inviteCode) {
+        User user = User.builder().build();
+        userRepository.save(user);
+        return Group.builder().inviteCode(inviteCode).leaderUser(user).build();
     }
 
 }

--- a/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
@@ -161,13 +161,16 @@ public class GroupServiceTest extends IntegrationTestSupport {
         String group2Title = "2번그룹";
         Group group1 = Group.builder().title(group1Title).build();
         Group group2 = Group.builder().title(group2Title).build();
-        groupRepository.saveAll(List.of(group1, group2));
+        Group group3 = Group.builder().title(group2Title).build();
+        groupRepository.saveAll(List.of(group1, group2, group3));
 
-        UserGroup userGroup1 = UserGroup.builder().user(user).group(group1)
-                .groupTitleAlias(group1.getTitle()).build();
+        UserGroup userGroup1 = UserGroup.builder().user(user).group(group1).
+                joinStatus(JoinStatus.JOINED).groupTitleAlias(group1.getTitle()).build();
         UserGroup userGroup2 = UserGroup.builder().user(user).group(group2)
-                .groupTitleAlias(group2.getTitle()).build();
-        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+                .joinStatus(JoinStatus.JOINED).groupTitleAlias(group2.getTitle()).build();
+        UserGroup userGroup3 = UserGroup.builder().user(user).group(group2)
+                .joinStatus(JoinStatus.REJECTED).groupTitleAlias(group2.getTitle()).build();
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2, userGroup3));
 
         //when
         List<GroupListResponse> responseList = groupService.getAllGroupList(user.getId());
@@ -175,8 +178,8 @@ public class GroupServiceTest extends IntegrationTestSupport {
         //then
         assertThat(responseList).hasSize(2);
         assertThat(responseList).extracting("groupId", "groupTitleAlias", "memberCount")
-                .contains(tuple(group1.getId(), group1Title, 1),
-                        tuple(group2.getId(), group2Title, 1));
+                .contains(tuple(group1.getId(), group1Title, 1L),
+                        tuple(group2.getId(), group2Title, 1L));
     }
 
     @Test

--- a/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
@@ -2,6 +2,7 @@ package seondays.shareticon.api.group;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.Mockito.doReturn;
 
@@ -12,6 +13,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -97,10 +99,14 @@ public class GroupServiceTest extends IntegrationTestSupport {
     void createGroupWithRetry(String displayName, List<String> inviteCodes, String expectedCode,
             boolean expectException) {
         //given
-        User user = userRepository.save(User.builder().build());
-        groupRepository.save(Group.builder().leaderUser(user).inviteCode("AAAAAAAA").build());
+        User user = User.builder().build();
+        userRepository.save(user);
 
+        String inviteCode = "AAAAAAAA";
         String groupTitle = "그룹이름";
+        Group group = Group.createNewGroup(user, inviteCode, groupTitle);
+        groupRepository.save(group);
+
         CreateGroupRequest request = new CreateGroupRequest(groupTitle);
 
         doReturn(inviteCodes.get(0), inviteCodes.get(1), inviteCodes.get(2))
@@ -154,26 +160,31 @@ public class GroupServiceTest extends IntegrationTestSupport {
     @DisplayName("해당 유저의 전체 그룹 리스트를 조회한다")
     void getAllGroupList() {
         //given
-        User user = User.builder().build();
-        userRepository.save(user);
+        User leader = User.builder().build();
+        User targetUser = User.builder().build();
+        userRepository.saveAll(List.of(leader, targetUser));
 
         String group1Title = "1번그룹";
         String group2Title = "2번그룹";
-        Group group1 = Group.builder().title(group1Title).build();
-        Group group2 = Group.builder().title(group2Title).build();
-        Group group3 = Group.builder().title(group2Title).build();
+        String inviteCode1 = "ABC";
+        String inviteCode2 = "DEF";
+        String inviteCode3 = "GHI";
+
+        Group group1 = Group.createNewGroup(leader, inviteCode1, group1Title);
+        Group group2 = Group.createNewGroup(leader, inviteCode2, group2Title);
+        Group group3 = Group.createNewGroup(leader, inviteCode3, group1Title);
         groupRepository.saveAll(List.of(group1, group2, group3));
 
-        UserGroup userGroup1 = UserGroup.builder().user(user).group(group1).
+        UserGroup userGroup1 = UserGroup.builder().user(targetUser).group(group1).
                 joinStatus(JoinStatus.JOINED).groupTitleAlias(group1.getTitle()).build();
-        UserGroup userGroup2 = UserGroup.builder().user(user).group(group2)
+        UserGroup userGroup2 = UserGroup.builder().user(targetUser).group(group2)
                 .joinStatus(JoinStatus.JOINED).groupTitleAlias(group2.getTitle()).build();
-        UserGroup userGroup3 = UserGroup.builder().user(user).group(group2)
+        UserGroup userGroup3 = UserGroup.builder().user(targetUser).group(group2)
                 .joinStatus(JoinStatus.REJECTED).groupTitleAlias(group2.getTitle()).build();
         userGroupRepository.saveAll(List.of(userGroup1, userGroup2, userGroup3));
 
         //when
-        List<GroupListResponse> responseList = groupService.getAllGroupList(user.getId());
+        List<GroupListResponse> responseList = groupService.getAllGroupList(targetUser.getId());
 
         //then
         assertThat(responseList).hasSize(2);
@@ -203,10 +214,11 @@ public class GroupServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().inviteCode("ok").build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+        ApplyToJoinRequest request = new ApplyToJoinRequest(inviteCode);
 
         //when
         groupService.applyToJoinGroup(request, user.getId());
@@ -217,7 +229,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
 
         assertThat(result).isNotEmpty();
         assertThat(result.get().getJoinStatus()).isEqualTo(JoinStatus.PENDING);
-        assertThat(result.get().getGroup().getInviteCode()).isEqualTo("ok");
+        assertThat(result.get().getGroup().getInviteCode()).isEqualTo(inviteCode);
         assertThat(result.get().getGroup().getId()).isEqualTo(group.getId());
         assertThat(result.get().getUser().getId()).isEqualTo(user.getId());
     }
@@ -228,10 +240,11 @@ public class GroupServiceTest extends IntegrationTestSupport {
         //given
         User user = User.builder().id(1L).build();
 
-        Group group = Group.builder().inviteCode("ok").build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+        ApplyToJoinRequest request = new ApplyToJoinRequest(inviteCode);
 
         //when //then
         assertThatThrownBy(() -> groupService.applyToJoinGroup(request, user.getId()))
@@ -259,7 +272,8 @@ public class GroupServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().inviteCode("ok").build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         JoinStatus status = JoinStatus.PENDING;
@@ -267,7 +281,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
                 .build();
         userGroupRepository.save(userGroup);
 
-        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+        ApplyToJoinRequest request = new ApplyToJoinRequest(inviteCode);
 
         //when //then
         assertThatThrownBy(() -> groupService.applyToJoinGroup(request, user.getId()))
@@ -281,7 +295,8 @@ public class GroupServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().inviteCode("ok").build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         JoinStatus status = JoinStatus.JOINED;
@@ -289,7 +304,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
                 .build();
         userGroupRepository.save(userGroup);
 
-        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+        ApplyToJoinRequest request = new ApplyToJoinRequest(inviteCode);
 
         //when //then
         assertThatThrownBy(() -> groupService.applyToJoinGroup(request, user.getId()))
@@ -303,7 +318,8 @@ public class GroupServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().inviteCode("ok").build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         JoinStatus status = JoinStatus.REJECTED;
@@ -311,7 +327,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
                 .build();
         userGroupRepository.save(userGroup);
 
-        ApplyToJoinRequest request = new ApplyToJoinRequest("ok");
+        ApplyToJoinRequest request = new ApplyToJoinRequest(inviteCode);
 
         //when
         groupService.applyToJoinGroup(request, user.getId());
@@ -326,7 +342,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
         Group resultGroup = result.get().getGroup();
 
         assertThat(resultGroup).isNotNull();
-        assertThat(resultGroup.getInviteCode()).isEqualTo("ok");
+        assertThat(resultGroup.getInviteCode()).isEqualTo(inviteCode);
         assertThat(resultGroup.getId()).isEqualTo(group.getId());
     }
 
@@ -385,7 +401,9 @@ public class GroupServiceTest extends IntegrationTestSupport {
         userRepository.save(leaderUser);
         userRepository.save(pendingUser);
 
-        Group group = Group.builder().build();
+        String inviteCode = "ABC";
+        String title = "test title";
+        Group group = Group.createNewGroup(leaderUser, inviteCode, title);
         groupRepository.save(group);
 
         UserGroup userGroup1 = UserGroup.builder().user(leaderUser).group(group)
@@ -399,7 +417,9 @@ public class GroupServiceTest extends IntegrationTestSupport {
                 leaderUser.getId());
 
         //then
-        assertThat(result).isEmpty();
+        assertThat(result.get(0).pendingMembers()).isEmpty();
+        assertThat(result.get(0).targetGroupId()).isEqualTo(group.getId());
+        assertThat(result.get(0).leaderGroupAlias()).isEqualTo(title);
     }
 
     @Test
@@ -558,7 +578,8 @@ public class GroupServiceTest extends IntegrationTestSupport {
         User pendingUser = User.builder().build();
         userRepository.save(pendingUser);
 
-        Group group = Group.builder().build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         //when //then
@@ -667,7 +688,8 @@ public class GroupServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         UserGroup userGroup = UserGroup.builder().group(group).user(user)
@@ -684,5 +706,11 @@ public class GroupServiceTest extends IntegrationTestSupport {
         //then
         assertThat(result.titleAlias()).isEqualTo(newAlias);
 
+    }
+
+    public Group createTestGroup(String inviteCode) {
+        User user = User.builder().build();
+        userRepository.save(user);
+        return Group.builder().inviteCode(inviteCode).leaderUser(user).build();
     }
 }

--- a/src/test/java/seondays/shareticon/api/user/UserControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/user/UserControllerTest.java
@@ -33,15 +33,16 @@ public class UserControllerTest extends ControllerTestSupport {
     }
 
     @Test
-    @DisplayName("유저 프로필 조회 시 결과에는 유저 닉네임, 유저 이메일, 유저가 가입한 그룹 카운트, 유저가 등록한 기프티콘 카운트가 포함된다")
+    @DisplayName("유저 프로필 조회 시 결과에는 유저 아이디, 유저 닉네임, 유저 이메일, 유저가 가입한 그룹 카운트, 유저가 등록한 기프티콘 카운트가 포함된다")
     void getUserProfile() throws Exception {
         //given
+        Long userId = mockUser.getId();
         String nickname = "닉네임";
         String email = "test@test";
         Long joinGroupCount = 1L;
         Long ownedVoucherCount = 2L;
 
-        UserProfileResponse mockResponse = UserProfileResponse.builder().nickName(nickname)
+        UserProfileResponse mockResponse = UserProfileResponse.builder().userId(userId).nickName(nickname)
                 .email(email).joinGroupCount(joinGroupCount).ownedVoucherCount(ownedVoucherCount)
                 .build();
 
@@ -55,6 +56,7 @@ public class UserControllerTest extends ControllerTestSupport {
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.userId").value(userId))
                 .andExpect(jsonPath("$.nickName").value(nickname))
                 .andExpect(jsonPath("$.email").value(email))
                 .andExpect(jsonPath("$.joinGroupCount").value(joinGroupCount))

--- a/src/test/java/seondays/shareticon/api/user/UserServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/user/UserServiceTest.java
@@ -42,8 +42,8 @@ public class UserServiceTest extends IntegrationTestSupport {
     void tearDown() {
         userGroupRepository.deleteAllInBatch();
         voucherRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
         groupRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
     }
 
     @Test
@@ -55,9 +55,9 @@ public class UserServiceTest extends IntegrationTestSupport {
         User user = User.builder().nickname(nickname).email(email).build();
         userRepository.save(user);
 
-        Group group = Group.builder().build();
-        Group group2 = Group.builder().build();
-        Group group3 = Group.builder().build();
+        Group group = createTestGroup("A");
+        Group group2 = createTestGroup("B");
+        Group group3 = createTestGroup("C");
         groupRepository.saveAll(List.of(group3, group2, group));
 
         linkUserWithGroup(user, group);
@@ -116,5 +116,11 @@ public class UserServiceTest extends IntegrationTestSupport {
         UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
         userGroupRepository.save(userGroup);
         return userGroup;
+    }
+
+    public Group createTestGroup(String inviteCode) {
+        User user = User.builder().build();
+        userRepository.save(user);
+        return Group.builder().inviteCode(inviteCode).leaderUser(user).build();
     }
 }

--- a/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.hibernate.mapping.Join;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,23 +59,26 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         Group group1 = Group.builder().build();
         Group group2 = Group.builder().build();
 
-        UserGroup userGroup1 = UserGroup.builder().user(user).group(group1).build();
-        UserGroup userGroup2 = UserGroup.builder().user(user).group(group2).build();
-        UserGroup userGroup3 = UserGroup.builder().user(user2).group(group2).build();
+        UserGroup userGroup1 = UserGroup.builder().user(user).joinStatus(JoinStatus.JOINED).group(group1).build();
+        UserGroup userGroup2 = UserGroup.builder().user(user).joinStatus(JoinStatus.JOINED).group(group2).build();
+        UserGroup userGroup3 = UserGroup.builder().user(user2).joinStatus(JoinStatus.REJECTED).group(group1).build();
+        UserGroup userGroup4 = UserGroup.builder().user(user2).joinStatus(JoinStatus.JOINED).group(group2).build();
 
         userRepository.saveAll(List.of(user, user2));
         groupRepository.saveAll(List.of(group1, group2));
-        userGroupRepository.saveAll(List.of(userGroup1, userGroup2, userGroup3));
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2, userGroup3, userGroup4));
 
         //when
-        List<GroupListResponse> result = userGroupRepository.findGroupsWithMemberCountByUserId(user.getId());
+        List<GroupListResponse> result = userGroupRepository
+                .findGroupsWithMemberCountByUserIdAndStatus(
+                        user.getId(), JoinStatus.getStatusesForAcceptedGroupMembers());
 
         //then
         assertThat(result.size()).isEqualTo(2);
         assertThat(result).extracting("groupId", "groupTitleAlias", "memberCount")
                 .containsExactlyInAnyOrder(
-                        tuple(group1.getId(), group1.getTitle(), 1),
-                        tuple(group2.getId(), group2.getTitle(), 2)
+                        tuple(group1.getId(), group1.getTitle(), 1L),
+                        tuple(group2.getId(), group2.getTitle(), 2L)
                 );
 
     }
@@ -87,7 +91,9 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         userRepository.save(user);
 
         //when
-        List<GroupListResponse> result = userGroupRepository.findGroupsWithMemberCountByUserId(user.getId());
+        List<GroupListResponse> result = userGroupRepository
+                .findGroupsWithMemberCountByUserIdAndStatus(
+                user.getId(), JoinStatus.getStatusesForAcceptedGroupMembers());
 
         //then
         assertThat(result).isEmpty();
@@ -115,7 +121,7 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         assertThat(result.get().getGroup()).isEqualTo(group);
 
     }
-    
+
     @Test
     @DisplayName("유저와 그룹 id에 해당하는 유저 그룹 정보가 없다면 빈 optional을 조회한다")
     void getUserGroupWithNotExistUserIdAndGroupId() {
@@ -145,10 +151,11 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         User user = User.builder().build();
 
         Group group = Group.builder().leaderUser(leader).build();
-        userRepository.saveAll(List.of(leader,user));
+        userRepository.saveAll(List.of(leader, user));
         groupRepository.save(group);
 
-        UserGroup userGroup = UserGroup.builder().user(user).group(group).joinStatus(JoinStatus.PENDING).build();
+        UserGroup userGroup = UserGroup.builder().user(user).group(group)
+                .joinStatus(JoinStatus.PENDING).build();
         userGroupRepository.save(userGroup);
 
         //when

--- a/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
@@ -36,10 +36,13 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
     void getUserWithGroup() {
         //given
         User user = User.builder().build();
-        Group group = Group.builder().build();
-        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
         userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
         userGroupRepository.save(userGroup);
 
         //when
@@ -55,17 +58,18 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         //given
         User user = User.builder().build();
         User user2 = User.builder().build();
+        userRepository.saveAll(List.of(user, user2));
 
-        Group group1 = Group.builder().build();
-        Group group2 = Group.builder().build();
+        String inviteCode1 = "ABC";
+        Group group1 = createTestGroup(inviteCode1);
+        String inviteCode2 = "DEF";
+        Group group2 = createTestGroup(inviteCode2);
+        groupRepository.saveAll(List.of(group1, group2));
 
         UserGroup userGroup1 = UserGroup.builder().user(user).joinStatus(JoinStatus.JOINED).group(group1).build();
         UserGroup userGroup2 = UserGroup.builder().user(user).joinStatus(JoinStatus.JOINED).group(group2).build();
         UserGroup userGroup3 = UserGroup.builder().user(user2).joinStatus(JoinStatus.REJECTED).group(group1).build();
         UserGroup userGroup4 = UserGroup.builder().user(user2).joinStatus(JoinStatus.JOINED).group(group2).build();
-
-        userRepository.saveAll(List.of(user, user2));
-        groupRepository.saveAll(List.of(group1, group2));
         userGroupRepository.saveAll(List.of(userGroup1, userGroup2, userGroup3, userGroup4));
 
         //when
@@ -104,8 +108,10 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
     void getUserGroupWithUserIdAndGroupId() {
         //given
         User user = User.builder().build();
-        Group group = Group.builder().build();
         userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         UserGroup userGroup = UserGroup.builder().group(group).user(user).build();
@@ -127,12 +133,11 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
     void getUserGroupWithNotExistUserIdAndGroupId() {
         //given
         User user = User.builder().build();
-        Group group = Group.builder().build();
         userRepository.save(user);
-        groupRepository.save(group);
 
-        UserGroup userGroup = UserGroup.builder().build();
-        userGroupRepository.save(userGroup);
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
+        groupRepository.save(group);
 
         //when
         Optional<UserGroup> result = userGroupRepository.findByUserIdAndGroupId(
@@ -149,9 +154,9 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         //given
         User leader = User.builder().build();
         User user = User.builder().build();
+        userRepository.saveAll(List.of(leader, user));
 
         Group group = Group.builder().leaderUser(leader).build();
-        userRepository.saveAll(List.of(leader, user));
         groupRepository.save(group);
 
         UserGroup userGroup = UserGroup.builder().user(user).group(group)
@@ -174,10 +179,13 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
     void auditingUserGroup() {
         //given
         User user = User.builder().build();
-        Group group = Group.builder().build();
-        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
         userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
         userGroupRepository.save(userGroup);
 
         //when
@@ -202,8 +210,11 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().build();
-        Group group2 = Group.builder().build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
+
+        String inviteCode2 = "DEF";
+        Group group2 = createTestGroup(inviteCode2);
         groupRepository.saveAll(List.of(group, group2));
 
         UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
@@ -231,5 +242,11 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         //then
         assertThat(result).isZero();
 
+    }
+
+    public Group createTestGroup(String inviteCode) {
+        User user = User.builder().build();
+        userRepository.save(user);
+        return Group.builder().inviteCode(inviteCode).leaderUser(user).build();
     }
 }

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
@@ -76,8 +76,8 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 jsonRequest.getBytes(StandardCharsets.UTF_8)
         );
 
-        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
-                VoucherStatus.AVAILABLE);
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName,
+                1L, expiration, VoucherStatus.AVAILABLE);
 
         when(voucherService.register(
                 any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
@@ -127,8 +127,8 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 jsonRequestWithoutGroupId.getBytes(StandardCharsets.UTF_8)
         );
 
-        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
-                VoucherStatus.AVAILABLE);
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName,
+                1L, expiration, VoucherStatus.AVAILABLE);
 
         when(voucherService.register(
                 any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
@@ -174,8 +174,8 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 jsonRequestWithoutGroupId.getBytes(StandardCharsets.UTF_8)
         );
 
-        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
-                VoucherStatus.AVAILABLE);
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName,
+                1L, expiration, VoucherStatus.AVAILABLE);
 
         when(voucherService.register(
                 any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
@@ -221,8 +221,8 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 jsonRequestWithoutGroupId.getBytes(StandardCharsets.UTF_8)
         );
 
-        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
-                VoucherStatus.AVAILABLE);
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName,
+                1L, expiration, VoucherStatus.AVAILABLE);
 
         when(voucherService.register(
                 any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
@@ -268,8 +268,8 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 jsonRequestWithoutGroupId.getBytes(StandardCharsets.UTF_8)
         );
 
-        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
-                VoucherStatus.AVAILABLE);
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName,
+                1L, expiration, VoucherStatus.AVAILABLE);
 
         when(voucherService.register(
                 any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
@@ -362,17 +362,18 @@ public class VoucherControllerTest extends ControllerTestSupport {
         int pageSize = 1;
         String mockPresignedUrl = "mockPresignedUrl";
 
+        User user = User.builder()
+                .id(userId)
+                .build();
         Voucher voucher = Voucher.builder()
                 .id(voucherId)
                 .image("www.image.com")
+                .user(user)
                 .status(VoucherStatus.AVAILABLE)
                 .build();
         Group group = Group.builder()
                 .id(groupId)
                 .inviteCode("InviteCode")
-                .build();
-        User user = User.builder()
-                .id(userId)
                 .build();
         UserGroup userGroup = UserGroup.builder()
                 .user(user)

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
@@ -34,15 +34,18 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
     @DisplayName("전체 쿠폰의 첫번째 페이지를 조회한다")
     void getAllVoucherWithFirstPage() {
         //given
-        Group group = Group.builder()
-                .build();
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        Voucher voucher1 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher2 = createVoucher(group, VoucherStatus.USED);
-        Voucher voucher3 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher4 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher5 = createVoucher(group, VoucherStatus.USED);
+        Voucher voucher1 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher2 = createVoucher(group, user, VoucherStatus.USED);
+        Voucher voucher3 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher4 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher5 = createVoucher(group, user, VoucherStatus.USED);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
 
         Pageable pageable = PageRequest.of(0, 2);
@@ -67,15 +70,18 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
     @DisplayName("전체 쿠폰의 두번째 페이지를 조회한다")
     void getAllVoucherWithCursor() {
         //given
-        Group group = Group.builder()
-                .build();
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        Voucher voucher1 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher2 = createVoucher(group, VoucherStatus.USED);
-        Voucher voucher3 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher4 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher5 = createVoucher(group, VoucherStatus.USED);
+        Voucher voucher1 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher2 = createVoucher(group, user, VoucherStatus.USED);
+        Voucher voucher3 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher4 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher5 = createVoucher(group, user, VoucherStatus.USED);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
 
         Pageable pageable = PageRequest.of(0, 2);
@@ -105,15 +111,18 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
     @DisplayName("전체 쿠폰의 마지막 페이지를 조회한다")
     void getAllVoucherWithLastPage() {
         //given
-        Group group = Group.builder()
-                .build();
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        Voucher voucher1 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher2 = createVoucher(group, VoucherStatus.USED);
-        Voucher voucher3 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher4 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher5 = createVoucher(group, VoucherStatus.USED);
+        Voucher voucher1 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher2 = createVoucher(group, user, VoucherStatus.USED);
+        Voucher voucher3 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher4 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher5 = createVoucher(group, user, VoucherStatus.USED);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
 
         Pageable pageable = PageRequest.of(0, 2);
@@ -145,15 +154,18 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
     @DisplayName("사용가능, 사용완료, 사용만료 상태인 쿠폰만 조회된다")
     void getVoucherStatusUsedAndAvailable() {
         //given
-        Group group = Group.builder()
-                .build();
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        Voucher voucher1 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher2 = createVoucher(group, VoucherStatus.USED);
-        Voucher voucher3 = createVoucher(group, VoucherStatus.EXPIRED);
-        Voucher voucher4 = createVoucher(group, VoucherStatus.AVAILABLE);
-        Voucher voucher5 = createVoucher(group, VoucherStatus.EXPIRED);
+        Voucher voucher1 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher2 = createVoucher(group, user, VoucherStatus.USED);
+        Voucher voucher3 = createVoucher(group, user, VoucherStatus.EXPIRED);
+        Voucher voucher4 = createVoucher(group, user, VoucherStatus.AVAILABLE);
+        Voucher voucher5 = createVoucher(group, user, VoucherStatus.EXPIRED);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
 
         List<VoucherStatus> voucherStatuses = VoucherStatus.forDisplayVoucherStatus();
@@ -175,8 +187,8 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
     @DisplayName("쿠폰이 존재하지 않을 때 조회하는 경우 예외 없이 빈 목록을 반환한다")
     void getEmptyVoucher() {
         //given
-        Group group = Group.builder()
-                .build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         Pageable pageable = PageRequest.of(0, 2);
@@ -199,8 +211,8 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder()
-                .build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         Voucher voucher1 = createVoucherWithUser(group, VoucherStatus.AVAILABLE, user);
@@ -233,9 +245,9 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
 
     }
 
-
-    private static Voucher createVoucher(Group group, VoucherStatus status) {
+    private static Voucher createVoucher(Group group, User user, VoucherStatus status) {
         return Voucher.builder()
+                .user(user)
                 .group(group)
                 .status(status)
                 .build();
@@ -247,5 +259,11 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
                 .user(user)
                 .status(status)
                 .build();
+    }
+
+    public Group createTestGroup(String inviteCode) {
+        User user = User.builder().build();
+        userRepository.save(user);
+        return Group.builder().inviteCode(inviteCode).leaderUser(user).build();
     }
 }

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -74,8 +74,8 @@ class VoucherServiceTest extends IntegrationTestSupport {
     void tearDown() {
         userGroupRepository.deleteAllInBatch();
         voucherRepository.deleteAllInBatch();
-        userRepository.deleteAllInBatch();
         groupRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
     }
 
     @Test
@@ -84,10 +84,13 @@ class VoucherServiceTest extends IntegrationTestSupport {
         //given
         User user = User.builder()
                 .build();
-        Group group = Group.builder().inviteCode("123").build();
-        String userGroupAlias = "그룹 별칭";
         userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
         linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
@@ -124,12 +127,14 @@ class VoucherServiceTest extends IntegrationTestSupport {
     @DisplayName("쿠폰 등록시 첨부 파일이 이미지 파일이 아니라면 예외가 발생한다.")
     void voucherRegisterWithNoImage() {
         //given
-        User user = User.builder()
-                .build();
-        Group group = Group.builder().build();
-        String userGroupAlias = "그룹 별칭";
+        User user = User.builder().build();
         userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
         linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
@@ -156,8 +161,10 @@ class VoucherServiceTest extends IntegrationTestSupport {
         //given
         User user = User.builder()
                 .build();
-        Group group = Group.builder().build();
         userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         String voucherName = "voucher name";
@@ -183,7 +190,8 @@ class VoucherServiceTest extends IntegrationTestSupport {
     @DisplayName("존재하지 않는 그룹에 쿠폰을 등록하는 경우 예외가 발생한다.")
     void registerVoucherWithNoExistGroup() {
         //given
-        Group group = Group.builder().build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         Long noExistUserId = 1L;
@@ -240,10 +248,13 @@ class VoucherServiceTest extends IntegrationTestSupport {
         //given
         User user = User.builder()
                 .build();
-        Group group = Group.builder().build();
-        String userGroupAlias = "그룹 별칭";
         userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
         linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
@@ -277,9 +288,11 @@ class VoucherServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().build();
-        String userGroupAlias = "그룹 별칭";
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
         linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
@@ -301,15 +314,16 @@ class VoucherServiceTest extends IntegrationTestSupport {
     void deleteVoucherWithNotRegisterUser() {
         //given
         User registerUser = User.builder().build();
-        User NotRegisterUser = User.builder().build();
-        userRepository.save(registerUser);
-        userRepository.save(NotRegisterUser);
+        User notRegisterUser = User.builder().build();
+        userRepository.saveAll(List.of(registerUser, notRegisterUser));
 
-        Group group = Group.builder().build();
-        String userGroupAlias = "그룹 별칭";
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
         linkUserWithGroup(registerUser, group, userGroupAlias);
-        linkUserWithGroup(NotRegisterUser, group, userGroupAlias);
+        linkUserWithGroup(notRegisterUser, group, userGroupAlias);
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -319,7 +333,7 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
         //when //then
         assertThatThrownBy(() ->
-                voucherService.delete(NotRegisterUser.getId(), group.getId(), voucher.getId()))
+                voucherService.delete(notRegisterUser.getId(), group.getId(), voucher.getId()))
                 .isInstanceOf(InvalidVoucherDeleteException.class);
     }
 
@@ -332,9 +346,11 @@ class VoucherServiceTest extends IntegrationTestSupport {
         userRepository.save(userExistInGroup);
         userRepository.save(userNoExistInGroup);
 
-        Group group = Group.builder().build();
-        String userGroupAlias = "그룹 별칭";
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
         linkUserWithGroup(userExistInGroup, group, userGroupAlias);
 
         String voucherName = "voucher name";
@@ -357,9 +373,11 @@ class VoucherServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().build();
-        String userGroupAlias = "그룹 별칭";
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
         UserGroup userGroup = linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
@@ -406,9 +424,11 @@ class VoucherServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().title("나의 그룹").build();
-        String userGroupAlias = "그룹 별칭";
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
         linkUserWithGroup(user, group, userGroupAlias);
 
         //when
@@ -433,7 +453,8 @@ class VoucherServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().build();
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
         LocalDate expiration = LocalDate.of(2025, 1, 1);
@@ -455,9 +476,11 @@ class VoucherServiceTest extends IntegrationTestSupport {
         User user = User.builder().build();
         userRepository.save(user);
 
-        Group group = Group.builder().build();
-        String userGroupAlias = "그룹 별칭";
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
         linkUserWithGroup(user, group, userGroupAlias);
 
         String voucherName = "voucher name";
@@ -489,5 +512,11 @@ class VoucherServiceTest extends IntegrationTestSupport {
         UserGroup userGroup = UserGroup.builder().user(user).group(group).groupTitleAlias(alias).build();
         userGroupRepository.save(userGroup);
         return userGroup;
+    }
+
+    public Group createTestGroup(String inviteCode) {
+        User user = User.builder().build();
+        userRepository.save(user);
+        return Group.builder().inviteCode(inviteCode).leaderUser(user).build();
     }
 }

--- a/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
@@ -93,8 +93,8 @@ public class GroupControllerDocsTest extends RestDocsSupport {
     @DisplayName("유저의 모든 그룹 리스트를 조회한다")
     void getAllGroupList() throws Exception {
         //given
-        GroupListResponse response1 = new GroupListResponse(1L, "title1", 2);
-        GroupListResponse response2 = new GroupListResponse(2L, "title2", 2);
+        GroupListResponse response1 = new GroupListResponse(1L, "title1", 2L);
+        GroupListResponse response2 = new GroupListResponse(2L, "title2", 2L);
         List<GroupListResponse> responseList = List.of(response1, response2);
 
         when(groupService.getAllGroupList(any(Long.class))).thenReturn(responseList);

--- a/src/test/java/seondays/shareticon/docs/user/UserControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/user/UserControllerDocsTest.java
@@ -37,14 +37,18 @@ public class UserControllerDocsTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("유저 프로필 조회 시 결과에는 유저 닉네임, 유저 이메일, 유저가 가입한 그룹 카운트, 유저가 등록한 기프티콘 카운트가 포함된다")
+    @DisplayName("유저 프로필 조회 시 결과에는 유저 아이디, 유저 닉네임, 유저 이메일, 유저가 가입한 그룹 카운트, 유저가 등록한 기프티콘 카운트가 포함된다")
     void getUserProfile() throws Exception {
         //given
+        Long userId = mockUser.getId();
         String nickname = "닉네임";
         String email = "test@test";
+        Long joinGroupCount = 1L;
+        Long ownedVoucherCount = 2L;
 
-        UserProfileResponse mockResponse = UserProfileResponse.builder().nickName(nickname)
-                .email(email).joinGroupCount(1L).ownedVoucherCount(2L).build();
+        UserProfileResponse mockResponse = UserProfileResponse.builder().userId(userId).nickName(nickname)
+                .email(email).joinGroupCount(joinGroupCount).ownedVoucherCount(ownedVoucherCount)
+                .build();
 
         //when
         when(userService.getUserProfile(any(Long.class))).thenReturn(mockResponse);
@@ -56,6 +60,7 @@ public class UserControllerDocsTest extends RestDocsSupport {
                 )
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.userId").value(userId))
                 .andExpect(jsonPath("$.nickName").value(nickname))
                 .andExpect(jsonPath("$.email").value(email))
                 .andExpect(jsonPath("$.joinGroupCount").value(1))
@@ -64,6 +69,7 @@ public class UserControllerDocsTest extends RestDocsSupport {
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         responseFields(
+                                fieldWithPath("userId").type(JsonFieldType.NUMBER).description("서버에서의 유저 아이디"),
                                 fieldWithPath("nickName").type(JsonFieldType.STRING).description("유저의 닉네임"),
                                 fieldWithPath("email").type(JsonFieldType.STRING).description("유저의 이메일"),
                                 fieldWithPath("joinGroupCount").type(JsonFieldType.NUMBER).description("유저가 가입되어 있는 그룹의 개수"),

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -83,8 +83,8 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                 jsonRequest.getBytes(StandardCharsets.UTF_8)
         );
 
-        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName, expiration,
-                VoucherStatus.AVAILABLE);
+        VouchersResponse mockResponse = new VouchersResponse(1L, "image", voucherName,
+                1L, expiration, VoucherStatus.AVAILABLE);
 
         when(voucherService.register(
                 any(CreateVoucherRequest.class), any(Long.class), any(MultipartFile.class)))
@@ -104,6 +104,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.status").value("AVAILABLE"))
                 .andExpect(jsonPath("$.presignedImage").value("image"))
+                .andExpect(jsonPath("$.registeredUserId").value(1L))
                 .andExpect(jsonPath("$.name").value(voucherName))
                 .andExpect(jsonPath("$.expiration").value(
                         expiration.format(DateTimeFormatter.ISO_LOCAL_DATE)))
@@ -129,6 +130,8 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                         .description("이미지 URL"),
                                 fieldWithPath("status").type(JsonFieldType.STRING)
                                         .description("쿠폰 상태 (AVAILABLE/EXPIRED/USED)"),
+                                fieldWithPath("registeredUserId").type(JsonFieldType.NUMBER)
+                                                .description("쿠폰을 등록한 유저의 ID"),
                                 fieldWithPath("name").type(JsonFieldType.STRING)
                                         .description("쿠폰 등록자가 설정한 쿠폰의 이름"),
                                 fieldWithPath("expiration").type(JsonFieldType.STRING)
@@ -175,19 +178,20 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
         LocalDate expiration = LocalDate.of(2025,1,1);
         String mockPresignedUrl = "mockPresignedUrl";
 
+        User user = User.builder()
+                .id(userId)
+                .build();
         Voucher voucher = Voucher.builder()
                 .id(voucherId)
                 .image("www.image.com")
                 .status(VoucherStatus.AVAILABLE)
                 .name(voucherName)
+                .user(user)
                 .expiration(expiration)
                 .build();
         Group group = Group.builder()
                 .id(groupId)
                 .inviteCode("InviteCode")
-                .build();
-        User user = User.builder()
-                .id(userId)
                 .build();
         UserGroup userGroup = UserGroup.builder()
                 .user(user)
@@ -244,6 +248,8 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("content[].vouchers[].status").type(
                                                 JsonFieldType.STRING)
                                         .description("쿠폰 사용 상태 (AVAILABLE/EXPIRED/USED)"),
+                                fieldWithPath("content[].vouchers[].registeredUserId").type(JsonFieldType.NUMBER)
+                                                .description("쿠폰을 등록한 유저의 ID"),
                                 fieldWithPath("content[].vouchers[].name").type(JsonFieldType.STRING)
                                                 .description("쿠폰 등록자가 설정한 쿠폰의 이름"),
                                 fieldWithPath("content[].vouchers[].expiration").type(JsonFieldType.STRING)


### PR DESCRIPTION
## 연관 이슈
close #32 

## 작업 내용
- 쿠폰 삭제를 위한 유저 id, 등록 유저 id 등 정보 추가와 이를 위한 response 형식 변경
- 쿠폰이 삭제되면 쿠폰 이미지 s3에서 삭제하도록 기능 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 쿠폰 이미지 삭제 실패 시 사용자에게 안내되는 예외 메시지가 추가되었습니다.
  * 그룹 목록, 유저 프로필, 쿠폰 응답 등에 사용자 ID 및 등록자 ID 정보가 추가되었습니다.

* **버그 수정**
  * 그룹 목록 조회 시, 가입이 승인된 그룹만 필터링하여 보여주도록 개선되었습니다.
  * 그룹 멤버 수, 쿠폰 응답 등에서 숫자 타입이 Long으로 변경되어 더 큰 값도 처리할 수 있게 되었습니다.

* **문서화**
  * API 응답 및 문서에 사용자 ID, 쿠폰 등록자 ID 등 신규 필드가 반영되었습니다.

* **테스트**
  * 변경된 데이터 타입 및 추가 필드에 맞게 테스트 코드와 문서화 테스트가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->