### PR TITLE
S3 coupon image refactor, retry & batch cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
 	// RestDocs
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+	// retry
+	implementation("org.springframework.retry:spring-retry:2.0.12")
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
 
 	// retry
 	implementation("org.springframework.retry:spring-retry:2.0.12")
+
+	// batch
+	implementation("org.springframework.batch:spring-batch-core:5.2.1")
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -66,10 +66,10 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
 	// retry
-	implementation("org.springframework.retry:spring-retry:2.0.12")
+	implementation("org.springframework.retry:spring-retry")
 
 	// batch
-	implementation("org.springframework.batch:spring-batch-core:5.2.1")
+	implementation("org.springframework.batch:spring-batch-core")
 }
 
 tasks.named('test') {

--- a/src/main/java/seondays/shareticon/ShareticonApplication.java
+++ b/src/main/java/seondays/shareticon/ShareticonApplication.java
@@ -3,7 +3,9 @@ package seondays.shareticon;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
+@EnableRetry
 @SpringBootApplication
 public class ShareticonApplication {
 

--- a/src/main/java/seondays/shareticon/ShareticonApplication.java
+++ b/src/main/java/seondays/shareticon/ShareticonApplication.java
@@ -2,10 +2,11 @@ package seondays.shareticon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableRetry
+@EnableScheduling
 @SpringBootApplication
 public class ShareticonApplication {
 

--- a/src/main/java/seondays/shareticon/group/GroupController.java
+++ b/src/main/java/seondays/shareticon/group/GroupController.java
@@ -37,7 +37,7 @@ public class GroupController {
             @AuthenticationPrincipal CustomOAuth2User userDetails,
             @Valid @RequestBody CreateGroupRequest request) {
         Long userId = userDetails.getId();
-        GroupResponse createdGroupResponse = groupService.createGroup(userId, request);
+        GroupResponse createdGroupResponse = groupService.registerNewGroup(userId, request);
 
         return ResponseEntity.created(URI.create("/group/" + createdGroupResponse.id()))
                 .body(createdGroupResponse);

--- a/src/main/java/seondays/shareticon/group/GroupFactory.java
+++ b/src/main/java/seondays/shareticon/group/GroupFactory.java
@@ -1,0 +1,48 @@
+package seondays.shareticon.group;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import seondays.shareticon.exception.GroupCreateException;
+import seondays.shareticon.group.dto.CreateGroupRequest;
+import seondays.shareticon.group.dto.GroupResponse;
+import seondays.shareticon.user.User;
+import seondays.shareticon.userGroup.UserGroup;
+import seondays.shareticon.userGroup.UserGroupRepository;
+
+@Component
+@RequiredArgsConstructor
+public class GroupFactory {
+
+    private final GroupRepository groupRepository;
+    private final UserGroupRepository userGroupRepository;
+    private final RandomCodeFactory randomCodeFactory;
+
+    @Retryable(
+            retryFor = {DataIntegrityViolationException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 50, multiplier = 2)
+    )
+    @Transactional
+    public GroupResponse createGroupWithRetry(User leaderUser, CreateGroupRequest request) {
+        String inviteCode = randomCodeFactory.createInviteCode();
+
+        Group newGroup = Group.createNewGroup(leaderUser, inviteCode, request.title());
+        groupRepository.save(newGroup);
+
+        UserGroup leaderUserGroup = UserGroup.createLeaderUserGroup(leaderUser, newGroup);
+        userGroupRepository.save(leaderUserGroup);
+
+        return GroupResponse.of(newGroup);
+    }
+
+    @Recover
+    public GroupResponse recoverGroupCreation(DataIntegrityViolationException e, User leaderUser,
+            CreateGroupRequest request) {
+        throw new GroupCreateException();
+    }
+}

--- a/src/main/java/seondays/shareticon/group/GroupFactory.java
+++ b/src/main/java/seondays/shareticon/group/GroupFactory.java
@@ -25,7 +25,7 @@ public class GroupFactory {
     @Retryable(
             retryFor = {DataIntegrityViolationException.class},
             maxAttempts = 3,
-            backoff = @Backoff(delay = 50, multiplier = 2)
+            backoff = @Backoff(delayExpression = "${retry.group-creation.delay}", multiplier = 2)
     )
     @Transactional
     public GroupResponse createGroupWithRetry(User leaderUser, CreateGroupRequest request) {

--- a/src/main/java/seondays/shareticon/group/GroupService.java
+++ b/src/main/java/seondays/shareticon/group/GroupService.java
@@ -4,10 +4,8 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import seondays.shareticon.exception.GroupCreateException;
 import seondays.shareticon.exception.GroupNotFoundException;
 import seondays.shareticon.exception.GroupUserNotFoundException;
 import seondays.shareticon.exception.UserNotFoundException;
@@ -26,7 +24,6 @@ import seondays.shareticon.userGroup.UserGroup;
 import seondays.shareticon.userGroup.UserGroupRepository;
 
 @Slf4j
-@Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
 public class GroupService {
@@ -34,40 +31,19 @@ public class GroupService {
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
     private final UserGroupRepository userGroupRepository;
-    private final RandomCodeFactory randomCodeFactory;
+    private final GroupFactory groupFactory;
     private final GroupValidator groupValidator;
 
-    @Transactional
-    public GroupResponse createGroup(Long userId, CreateGroupRequest request) {
+    public GroupResponse registerNewGroup(Long userId, CreateGroupRequest request) {
         User leaderUser = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
-        int maxRetry = 3;
-        int retryCount = 0;
-
-        while (retryCount < maxRetry) {
-
-            try {
-                String inviteCode = randomCodeFactory.createInviteCode();
-
-                Group newGroup = Group.createNewGroup(leaderUser, inviteCode, request.title());
-                groupRepository.save(newGroup);
-
-                UserGroup leaderUserGroup = UserGroup.createLeaderUserGroup(leaderUser, newGroup);
-                userGroupRepository.save(leaderUserGroup);
-
-                return GroupResponse.of(newGroup);
-            } catch (DataIntegrityViolationException e) {
-                retryCount++;
-                log.warn("{} 유저 그룹 생성 시도 중, 초대코드 중복 발생 : 재시도 {}/{}", userId,
-                        retryCount, maxRetry);
-            }
-        }
-        throw new GroupCreateException();
+        return groupFactory.createGroupWithRetry(leaderUser, request);
     }
 
+    @Transactional(readOnly = true)
     public List<GroupListResponse> getAllGroupList(Long userId) {
         return userGroupRepository.findGroupsWithMemberCountByUserIdAndStatus(
-                userId, JoinStatus.getStatusesForAcceptedGroupMembers())
+                        userId, JoinStatus.getStatusesForAcceptedGroupMembers())
                 .stream()
                 .toList();
     }
@@ -87,6 +63,7 @@ public class GroupService {
         userGroupRepository.save(userGroup);
     }
 
+    @Transactional(readOnly = true)
     public List<ApplyToJoinResponse> getAllGroupPendingUserList(Long leaderUserId) {
         groupValidator.validateExistTargetUser(leaderUserId);
 

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -28,7 +28,9 @@ public class ImageService {
     @Value("${aws.s3.bucket}")
     private String bucket;
 
-    public String uploadImage(MultipartFile image) {
+    public String uploadImage(VoucherImage voucherImage) {
+        MultipartFile image = voucherImage.getImageFile();
+
         String uploadTitle = makeUploadTitle("voucher", image.getOriginalFilename());
 
         try {

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -109,6 +109,17 @@ public class ImageService {
         s3Client.deleteObject(deleteObjectRequest);
     }
 
+    public void deleteImage(Voucher voucher) {
+        String key = voucher.getImage();
+
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+
     @Recover
     public void recoverImageDelete(Exception e, Voucher voucher) {
         log.error("S3 이미지 삭제 시도 3회 실패 : {}번 쿠폰의 {}", voucher.getId(), voucher.getImage());

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -4,21 +4,27 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import seondays.shareticon.exception.ImageDeleteException;
 import seondays.shareticon.exception.ImageUploadException;
 import seondays.shareticon.exception.PresignedUrlGenerationException;
+import seondays.shareticon.voucher.Voucher;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ImageService {
@@ -28,7 +34,12 @@ public class ImageService {
     @Value("${aws.s3.bucket}")
     private String bucket;
 
-    public String uploadImage(VoucherImage voucherImage) {
+    @Retryable(
+            retryFor = {ImageUploadException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public String uploadImageWithRetry(VoucherImage voucherImage) {
         MultipartFile image = voucherImage.getImageFile();
 
         String uploadTitle = makeUploadTitle("voucher", image.getOriginalFilename());
@@ -51,15 +62,6 @@ public class ImageService {
         }
     }
 
-    public String makeUploadTitle(String prefix, String filename) {
-        String extension = "";
-        int index = filename.lastIndexOf('.');
-        if (index > 0) {
-            extension = filename.substring(index);
-        }
-        return prefix + "/" + UUID.randomUUID() + extension;
-    }
-
     public String getPresignedImageUrl(String objectKey, Long expirationMinutes) {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(bucket)
@@ -80,7 +82,13 @@ public class ImageService {
         }
     }
 
-    public void deleteImage(String key) {
+    @Retryable(
+            retryFor = {ImageDeleteException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 1000, multiplier = 2)
+    )
+    public void deleteImageWithRetry(Voucher voucher) {
+        String key = voucher.getImage();
         try {
             DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
                     .bucket(bucket)
@@ -88,8 +96,17 @@ public class ImageService {
                     .build();
 
             s3Client.deleteObject(deleteObjectRequest);
-        } catch (Exception e) {
+        } catch (S3Exception e) {
             throw new ImageDeleteException();
         }
+    }
+
+    private String makeUploadTitle(String prefix, String filename) {
+        String extension = "";
+        int index = filename.lastIndexOf('.');
+        if (index > 0) {
+            extension = filename.substring(index);
+        }
+        return prefix + "/" + UUID.randomUUID() + extension;
     }
 }

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -40,7 +40,7 @@ public class ImageService {
             retryFor = {SdkClientException.class},
             noRetryFor = {S3Exception.class},
             maxAttempts = 3,
-            backoff = @Backoff(delay = 1000, multiplier = 2)
+            backoff = @Backoff(delayExpression = "${retry.S3-Image-service.delay}", multiplier = 2)
     )
     public String uploadImageWithRetry(VoucherImage voucherImage) {
 
@@ -96,7 +96,7 @@ public class ImageService {
             retryFor = {SdkClientException.class},
             noRetryFor = {S3Exception.class},
             maxAttempts = 3,
-            backoff = @Backoff(delay = 1000, multiplier = 2)
+            backoff = @Backoff(delayExpression = "${retry.S3-Image-service.delay}", multiplier = 2)
     )
     public void deleteImageWithRetry(Voucher voucher) {
         String key = voucher.getImage();

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -14,6 +15,7 @@ import seondays.shareticon.exception.ImageDeleteException;
 import seondays.shareticon.exception.ImageUploadException;
 import seondays.shareticon.exception.PresignedUrlGenerationException;
 import seondays.shareticon.voucher.Voucher;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
@@ -35,16 +37,18 @@ public class ImageService {
     private String bucket;
 
     @Retryable(
-            retryFor = {ImageUploadException.class},
+            retryFor = {SdkClientException.class},
+            noRetryFor = {S3Exception.class},
             maxAttempts = 3,
             backoff = @Backoff(delay = 1000, multiplier = 2)
     )
     public String uploadImageWithRetry(VoucherImage voucherImage) {
-        MultipartFile image = voucherImage.getImageFile();
-
-        String uploadTitle = makeUploadTitle("voucher", image.getOriginalFilename());
 
         try {
+            MultipartFile image = voucherImage.getImageFile();
+
+            String uploadTitle = makeUploadTitle("voucher", image.getOriginalFilename());
+
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucket)
                     .key(uploadTitle)
@@ -60,6 +64,12 @@ public class ImageService {
         } catch (IOException e) {
             throw new ImageUploadException();
         }
+    }
+
+    @Recover
+    public String recoverImageUpload(Exception e, VoucherImage voucherImage) {
+        log.error("S3 이미지 업로드 시도 실패");
+        throw new ImageUploadException();
     }
 
     public String getPresignedImageUrl(String objectKey, Long expirationMinutes) {
@@ -83,22 +93,26 @@ public class ImageService {
     }
 
     @Retryable(
-            retryFor = {ImageDeleteException.class},
+            retryFor = {SdkClientException.class},
+            noRetryFor = {S3Exception.class},
             maxAttempts = 3,
             backoff = @Backoff(delay = 1000, multiplier = 2)
     )
     public void deleteImageWithRetry(Voucher voucher) {
         String key = voucher.getImage();
-        try {
-            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
-                    .bucket(bucket)
-                    .key(key)
-                    .build();
 
-            s3Client.deleteObject(deleteObjectRequest);
-        } catch (S3Exception e) {
-            throw new ImageDeleteException();
-        }
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteObjectRequest);
+    }
+
+    @Recover
+    public void recoverImageDelete(Exception e, Voucher voucher) {
+        log.error("S3 이미지 삭제 시도 3회 실패 : {}번 쿠폰의 {}", voucher.getId(), voucher.getImage());
+        throw new ImageDeleteException();
     }
 
     private String makeUploadTitle(String prefix, String filename) {

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -109,17 +109,6 @@ public class ImageService {
         s3Client.deleteObject(deleteObjectRequest);
     }
 
-    public void deleteImage(Voucher voucher) {
-        String key = voucher.getImage();
-
-        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
-                .bucket(bucket)
-                .key(key)
-                .build();
-
-        s3Client.deleteObject(deleteObjectRequest);
-    }
-
     @Recover
     public void recoverImageDelete(Exception e, Voucher voucher) {
         log.error("S3 이미지 삭제 시도 3회 실패 : {}번 쿠폰의 {}", voucher.getId(), voucher.getImage());

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -50,7 +50,12 @@ public class ImageService {
     }
 
     public String makeUploadTitle(String prefix, String filename) {
-        return prefix + "/" + UUID.randomUUID() + "-" + filename;
+        String extension = "";
+        int index = filename.lastIndexOf('.');
+        if (index > 0) {
+            extension = filename.substring(index);
+        }
+        return prefix + "/" + UUID.randomUUID() + extension;
     }
 
     public String getPresignedImageUrl(String objectKey, Long expirationMinutes) {

--- a/src/main/java/seondays/shareticon/image/batch/S3ImageCleanupBatchProcess.java
+++ b/src/main/java/seondays/shareticon/image/batch/S3ImageCleanupBatchProcess.java
@@ -1,0 +1,100 @@
+package seondays.shareticon.image.batch;
+
+import jakarta.persistence.EntityManagerFactory;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemStreamReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import seondays.shareticon.config.TokenTimeConfig;
+import seondays.shareticon.image.ImageService;
+import seondays.shareticon.voucher.Voucher;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class S3ImageCleanupBatchProcess {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+    private final EntityManagerFactory entityManagerFactory;
+    private final ImageService imageService;
+    private final TokenTimeConfig clock;
+
+    @Bean
+    public Job voucherImageCleanupJob(Step voucherImageCleanupStep) {
+        return new JobBuilder("voucherImageCleanupJob", jobRepository)
+                .start(voucherImageCleanupStep)
+                .build();
+    }
+
+    @Bean
+    public Step voucherImageCleanupStep(ItemReader<Voucher> voucherReader) {
+        return new StepBuilder("voucherImageCleanupStep", jobRepository)
+                .<Voucher, Voucher>chunk(10, transactionManager)
+                .reader(voucherReader)
+                .processor(voucherImageCleanupProcessor())
+                .writer(voucherWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemStreamReader<Voucher> voucherReader(
+            @Value("#{jobParameters['executionDate']}") String executionDateString) {
+        LocalDateTime executionDateTime = Optional.ofNullable(executionDateString)
+                .map(LocalDateTime::parse)
+                .orElse(LocalDateTime.now(clock.clock()));
+
+        LocalDateTime executionScope = executionDateTime.minusMonths(2);
+
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("executionScope", executionScope);
+
+        return new JpaPagingItemReaderBuilder<Voucher>()
+                .name("voucherReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString(
+                        "SELECT v FROM Voucher v WHERE v.isDeleted = true AND v.modifiedDateTime >= :executionScope")
+                .parameterValues(parameters)
+                .pageSize(100)
+                .build();
+    }
+
+    @Bean
+    public ItemProcessor<Voucher, Voucher> voucherImageCleanupProcessor() {
+        return voucher -> {
+            try {
+                imageService.deleteImage(voucher);
+                return voucher;
+            } catch (Exception e) {
+                log.warn("배치 처리 중 이미지 삭제 실패 : Voucher {}", voucher.getId());
+                return null;
+            }
+        };
+    }
+
+    @Bean
+    public ItemWriter<Voucher> voucherWriter() {
+        return items -> {
+
+        };
+    }
+
+}

--- a/src/main/java/seondays/shareticon/image/batch/S3ImageCleanupBatchProcess.java
+++ b/src/main/java/seondays/shareticon/image/batch/S3ImageCleanupBatchProcess.java
@@ -81,7 +81,7 @@ public class S3ImageCleanupBatchProcess {
     public ItemProcessor<Voucher, Voucher> voucherImageCleanupProcessor() {
         return voucher -> {
             try {
-                imageService.deleteImage(voucher);
+                imageService.deleteImageWithRetry(voucher);
                 return voucher;
             } catch (Exception e) {
                 log.warn("배치 처리 중 이미지 삭제 실패 : Voucher {}", voucher.getId());

--- a/src/main/java/seondays/shareticon/image/batch/S3ImageCleanupBatchScheduler.java
+++ b/src/main/java/seondays/shareticon/image/batch/S3ImageCleanupBatchScheduler.java
@@ -1,0 +1,41 @@
+package seondays.shareticon.image.batch;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class S3ImageCleanupBatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job voucherImageCleanupJob;
+    private final Clock clock;
+
+    @Scheduled(cron = "0 0 0 1 1/2 ?")
+    public void runVoucherImageCleanupJob() {
+        try {
+            LocalDateTime now = LocalDateTime.now(clock);
+
+            JobParameters jobParameters = new JobParametersBuilder()
+                    .addString("jobId", now.format(DateTimeFormatter.ofPattern("yyyyMMdd")))
+                    .addString("executionDate", now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                    .toJobParameters();
+
+            jobLauncher.run(voucherImageCleanupJob, jobParameters);
+        } catch (Exception e) {
+            log.error("이미지 삭제 작업 실패");
+        }
+    }
+}

--- a/src/main/java/seondays/shareticon/user/UserService.java
+++ b/src/main/java/seondays/shareticon/user/UserService.java
@@ -24,7 +24,7 @@ public class UserService {
 
         Long joinGroupCount = userGroupRepository.countByUserId(userId);
 
-        Long ownedVoucherCount = voucherRepository.countByUserId(userId);
+        Long ownedVoucherCount = voucherRepository.countByUserIdAndIsDeletedFalse(userId);
 
         return UserProfileResponse.of(user, joinGroupCount, ownedVoucherCount);
     }

--- a/src/main/java/seondays/shareticon/voucher/Voucher.java
+++ b/src/main/java/seondays/shareticon/voucher/Voucher.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.voucher;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -44,6 +45,8 @@ public class Voucher extends BaseEntity {
     private String image;
     @Enumerated(value = EnumType.STRING)
     private VoucherStatus status;
+    @Column(name = "is_deleted")
+    private boolean isDeleted;
 
     public static Voucher createNewVoucher(User user, Group group, String name, String imageKey,
             LocalDate expiration) {
@@ -53,8 +56,13 @@ public class Voucher extends BaseEntity {
                 .name(name)
                 .image(imageKey)
                 .expiration(expiration)
+                .isDeleted(false)
                 .status(VoucherStatus.AVAILABLE)
                 .build();
+    }
+
+    public void delete() {
+        isDeleted = true;
     }
 
     public void changeStatus() {

--- a/src/main/java/seondays/shareticon/voucher/Voucher.java
+++ b/src/main/java/seondays/shareticon/voucher/Voucher.java
@@ -45,19 +45,16 @@ public class Voucher extends BaseEntity {
     @Enumerated(value = EnumType.STRING)
     private VoucherStatus status;
 
-    public static Voucher createAvailableStatus(User user, Group group, String name,
+    public static Voucher createNewVoucher(User user, Group group, String name, String imageKey,
             LocalDate expiration) {
         return Voucher.builder()
                 .user(user)
                 .group(group)
                 .name(name)
+                .image(imageKey)
                 .expiration(expiration)
                 .status(VoucherStatus.AVAILABLE)
                 .build();
-    }
-
-    public void saveImage(String image) {
-        this.image = image;
     }
 
     public void changeStatus() {

--- a/src/main/java/seondays/shareticon/voucher/VoucherFactory.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherFactory.java
@@ -1,0 +1,22 @@
+package seondays.shareticon.voucher;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import seondays.shareticon.group.Group;
+import seondays.shareticon.user.User;
+import seondays.shareticon.voucher.dto.CreateVoucherRequest;
+
+@Component
+@RequiredArgsConstructor
+public class VoucherFactory {
+
+    private final VoucherRepository voucherRepository;
+
+    @Transactional
+    public Voucher createVoucherWithImage(User user, Group group, CreateVoucherRequest request, String imageKey) {
+        Voucher newVoucher = Voucher.createNewVoucher(user, group, request.voucherName(), imageKey,
+                request.expiration());
+        return voucherRepository.save(newVoucher);
+    }
+}

--- a/src/main/java/seondays/shareticon/voucher/VoucherRepository.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherRepository.java
@@ -1,6 +1,7 @@
 package seondays.shareticon.voucher;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -16,11 +17,15 @@ public interface VoucherRepository extends JpaRepository<Voucher, Long> {
             where v.group.id= :groupId
             and v.status in :voucherStatuses
             and (:cursorId is null or v.id < :cursorId)
+            and v.isDeleted = false
             order by v.id DESC
             """)
     Slice<Voucher> findAllPageWithCursorByDesc(@Param("groupId") Long groupId,
             @Param("voucherStatuses") List<VoucherStatus> voucherStatuses,
             @Param("cursorId") Long cursorId, Pageable pageable);
 
-    Long countByUserId(Long userId);
+    Long countByUserIdAndIsDeletedFalse(Long userId);
+
+    @Query("SELECT v FROM Voucher v WHERE v.id = :voucherId AND v.isDeleted = false")
+    Optional<Voucher> findById(Long voucherId);
 }

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -39,6 +39,7 @@ public class VoucherService {
     private final VoucherRepository voucherRepository;
     private final UserGroupRepository userGroupRepository;
     private final VoucherValidator voucherValidator;
+    private final VoucherFactory voucherFactory;
 
     /**
      * 새로운 쿠폰을 등록합니다.
@@ -48,14 +49,11 @@ public class VoucherService {
      * @param image
      * @return
      */
-    @Transactional
     public VouchersResponse register(CreateVoucherRequest request, Long userId,
             MultipartFile image) {
         Long groupId = request.groupId();
-
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         Group group = groupRepository.findById(groupId).orElseThrow(GroupNotFoundException::new);
-        VoucherImage voucherImage = VoucherImage.of(image);
 
         VoucherCreationValidationRequest validationRequest = VoucherCreationValidationRequest
                 .builder()
@@ -65,34 +63,14 @@ public class VoucherService {
                 .build();
         voucherValidator.validateVoucherCreation(validationRequest);
 
-        Voucher voucher = createVoucherWithImage(user, group, voucherImage, request.voucherName(),
-                request.expiration());
+        VoucherImage voucherImage = VoucherImage.of(image);
+        String imageKey = imageService.uploadImage(voucherImage);
+
+        Voucher voucher = voucherFactory.createVoucherWithImage(user, group, request, imageKey);
 
         String preSignedUrl = imageService.getPresignedImageUrl(voucher.getImage(), 5L);
 
         return VouchersResponse.of(voucher, preSignedUrl);
-    }
-
-    /**
-     * 이미지를 포함하는 쿠폰 객체를 생성합니다.
-     *
-     * @param user
-     * @param group
-     * @param image
-     * @param name
-     * @param expiration
-     * @return
-     */
-    private Voucher createVoucherWithImage(User user, Group group, VoucherImage image, String name,
-            LocalDate expiration) {
-        String imageUrl = imageService.uploadImage(image.getImageFile());
-
-        Voucher voucher = Voucher.createAvailableStatus(user, group, name, expiration);
-        voucherRepository.save(voucher);
-
-        voucher.saveImage(imageUrl);
-
-        return voucherRepository.save(voucher);
     }
 
     /**

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -92,7 +92,7 @@ public class VoucherService {
                 .build();
         voucherValidator.validateVoucherDeletion(validationRequest);
 
-        voucherRepository.delete(voucher);
+        voucher.delete();
 
         imageService.deleteImage(voucher.getImage());
     }

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -1,6 +1,5 @@
 package seondays.shareticon.voucher;
 
-import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -64,7 +63,7 @@ public class VoucherService {
         voucherValidator.validateVoucherCreation(validationRequest);
 
         VoucherImage voucherImage = VoucherImage.of(image);
-        String imageKey = imageService.uploadImage(voucherImage);
+        String imageKey = imageService.uploadImageWithRetry(voucherImage);
 
         Voucher voucher = voucherFactory.createVoucherWithImage(user, group, request, imageKey);
 
@@ -94,7 +93,7 @@ public class VoucherService {
 
         voucher.delete();
 
-        imageService.deleteImage(voucher.getImage());
+        imageService.deleteImageWithRetry(voucher);
     }
 
     /**

--- a/src/test/java/seondays/shareticon/api/config/IntegrationTestSupport.java
+++ b/src/test/java/seondays/shareticon/api/config/IntegrationTestSupport.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
@@ -13,6 +14,7 @@ import org.testcontainers.utility.DockerImageName;
 import seondays.shareticon.group.RandomCodeFactory;
 import seondays.shareticon.image.ImageService;
 
+@EnableScheduling
 @EnableRetry
 @Testcontainers
 @ActiveProfiles("test")

--- a/src/test/java/seondays/shareticon/api/config/IntegrationTestSupport.java
+++ b/src/test/java/seondays/shareticon/api/config/IntegrationTestSupport.java
@@ -3,6 +3,7 @@ package seondays.shareticon.api.config;
 import java.time.Clock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
@@ -12,6 +13,7 @@ import org.testcontainers.utility.DockerImageName;
 import seondays.shareticon.group.RandomCodeFactory;
 import seondays.shareticon.image.ImageService;
 
+@EnableRetry
 @Testcontainers
 @ActiveProfiles("test")
 @SpringBootTest
@@ -28,9 +30,6 @@ public abstract class IntegrationTestSupport {
 
     @MockitoSpyBean
      protected RandomCodeFactory randomCodeFactory;
-
-    @MockitoBean
-    protected ImageService imageService;
 
     @MockitoBean
     protected Clock clock;

--- a/src/test/java/seondays/shareticon/api/group/GroupControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupControllerTest.java
@@ -51,7 +51,7 @@ public class GroupControllerTest extends ControllerTestSupport {
         CreateGroupRequest request = new CreateGroupRequest("그룹 이름");
         String json = mapper.writeValueAsString(request);
 
-        when(groupService.createGroup(any(Long.class), any(CreateGroupRequest.class)))
+        when(groupService.registerNewGroup(any(Long.class), any(CreateGroupRequest.class)))
                 .thenReturn(GroupResponse.of(createdGroup));
 
         //when //then

--- a/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
@@ -2,7 +2,6 @@ package seondays.shareticon.api.group;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.in;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.Mockito.doReturn;
 
@@ -73,7 +72,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
         CreateGroupRequest request = new CreateGroupRequest(groupTitle);
 
         //when
-        GroupResponse groupResponse = groupService.createGroup(user.getId(), request);
+        GroupResponse groupResponse = groupService.registerNewGroup(user.getId(), request);
 
         //then
         assertThat(groupResponse).isNotNull();
@@ -89,7 +88,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
         CreateGroupRequest request = new CreateGroupRequest(groupTitle);
 
         //when //then
-        assertThatThrownBy(() -> groupService.createGroup(user.getId(), request)).isInstanceOf(
+        assertThatThrownBy(() -> groupService.registerNewGroup(user.getId(), request)).isInstanceOf(
                 UserNotFoundException.class);
     }
 
@@ -114,10 +113,10 @@ public class GroupServiceTest extends IntegrationTestSupport {
 
         //when //then
         if (expectException) {
-            assertThatThrownBy(() -> groupService.createGroup(user.getId(), request))
+            assertThatThrownBy(() -> groupService.registerNewGroup(user.getId(), request))
                     .isInstanceOf(GroupCreateException.class);
         } else {
-            GroupResponse groupResponse = groupService.createGroup(user.getId(), request);
+            GroupResponse groupResponse = groupService.registerNewGroup(user.getId(), request);
             assertThat(groupResponse.inviteCode()).isEqualTo(expectedCode);
         }
     }
@@ -145,7 +144,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
         CreateGroupRequest request = new CreateGroupRequest(groupTitle);
 
         //when
-        GroupResponse createdGroup = groupService.createGroup(user.getId(), request);
+        GroupResponse createdGroup = groupService.registerNewGroup(user.getId(), request);
 
         //then
         Optional<UserGroup> result = userGroupRepository.findByUserIdAndGroupId(
@@ -658,7 +657,7 @@ public class GroupServiceTest extends IntegrationTestSupport {
         for (int i = 0; i < threadCount; i++) {
             executor.submit(() -> {
                 try {
-                    groupService.createGroup(leaderUser.getId(), request);
+                    groupService.registerNewGroup(leaderUser.getId(), request);
                     successCount.incrementAndGet();
                 } catch (Exception e) {
                     failCount.incrementAndGet();

--- a/src/test/java/seondays/shareticon/api/image/ImageServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/image/ImageServiceTest.java
@@ -1,0 +1,268 @@
+package seondays.shareticon.api.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.web.multipart.MultipartFile;
+import seondays.shareticon.api.config.IntegrationTestSupport;
+import seondays.shareticon.exception.ImageDeleteException;
+import seondays.shareticon.exception.ImageUploadException;
+import seondays.shareticon.image.ImageService;
+import seondays.shareticon.image.VoucherImage;
+import seondays.shareticon.voucher.Voucher;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+public class ImageServiceTest extends IntegrationTestSupport {
+
+    @MockitoBean
+    private S3Client s3Client;
+
+    @MockitoBean
+    private S3Presigner s3Presigner;
+
+    @Autowired
+    private ImageService imageService;
+
+    @Test
+    @DisplayName("이미지를 정상 업로드하면 정상 key가 반환된다")
+    void uploadImage() {
+        //given
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test".getBytes()
+        );
+
+        VoucherImage voucherImage = VoucherImage.of(imageFile);
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(mock(PutObjectResponse.class));
+
+        //when
+        String result = imageService.uploadImageWithRetry(voucherImage);
+
+        //then
+        assertThat(result).startsWith("voucher");
+        assertThat(result).endsWith(".jpg");
+
+    }
+
+    @Test
+    @DisplayName("SdkClientException이 발생하는 실패는 최대 3회 재시도한다")
+    void uploadImageWithSdkClientException() {
+        //given
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test".getBytes()
+        );
+
+        VoucherImage voucherImage = VoucherImage.of(imageFile);
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenThrow(SdkClientException.class);
+
+        //when
+        assertThatThrownBy(() -> imageService.uploadImageWithRetry(voucherImage))
+                .isInstanceOf(ImageUploadException.class);
+
+        //then
+        verify(s3Client, times(3))
+                .putObject(any(PutObjectRequest.class), any(RequestBody.class));
+
+    }
+
+    @Test
+    @DisplayName("인증 실패나 권한 없음 등, S3Exception이 발생하는 실패는 재시도하지 않고 저장이 최종 실패한다")
+    void uploadImageWithS3Exception() {
+        //given
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test".getBytes()
+        );
+
+        VoucherImage voucherImage = VoucherImage.of(imageFile);
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenThrow(S3Exception.class);
+
+        //when
+        assertThatThrownBy(() -> imageService.uploadImageWithRetry(voucherImage))
+                .isInstanceOf(ImageUploadException.class);
+
+        //then
+        verify(s3Client, times(1))
+                .putObject(any(PutObjectRequest.class), any(RequestBody.class));
+
+    }
+
+    @Test
+    @DisplayName("IOException이 발생하는 실패는 재시도하지 않고 바로 저장이 최종 실패한다")
+    void uploadImageWithIOExcepiton() throws IOException {
+        //given
+        MultipartFile imageFile = mock(MultipartFile.class);
+        when(imageFile.getContentType()).thenReturn("image");
+        when(imageFile.getInputStream()).thenThrow(IOException.class);
+
+        VoucherImage voucherImage = VoucherImage.of(imageFile);
+
+        //when
+        assertThatThrownBy(() -> imageService.uploadImageWithRetry(voucherImage))
+                .isInstanceOf(ImageUploadException.class);
+
+        //then
+        verify(s3Client, never())
+                .putObject(any(PutObjectRequest.class), any(RequestBody.class));
+
+    }
+
+    @Test
+    @DisplayName("이미지 업로드 실패 시, 3회 재시도 중 1회만 성공하면 최종 성공한다")
+    void uploadImageSucceedWithRetry() {
+        //given
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "image",
+                "test.jpg",
+                "image/jpeg",
+                "test".getBytes()
+        );
+
+        VoucherImage voucherImage = VoucherImage.of(imageFile);
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenThrow(SdkClientException.class).thenReturn(mock(PutObjectResponse.class));
+
+        //when
+        String result = imageService.uploadImageWithRetry(voucherImage);
+
+        //then
+        assertThat(result).startsWith("voucher");
+        assertThat(result).endsWith(".jpg");
+
+    }
+
+    @Test
+    @DisplayName("저장 key를 가지고 presigned URL을 생성한다")
+    void makePresignedImageUrl() throws MalformedURLException {
+        //given
+        String expectedUrl = "http://www.image.com";
+        PresignedGetObjectRequest mockRequest = mock(PresignedGetObjectRequest.class);
+
+        when(mockRequest.url()).thenReturn(new URL(expectedUrl));
+
+        when(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class))).thenReturn(
+                mockRequest);
+
+        String objectKey = "key";
+        Long expiration = 1L;
+
+        //when
+        String result = imageService.getPresignedImageUrl(objectKey, expiration);
+
+        //then
+        assertThat(result).isEqualTo(expectedUrl);
+        verify(s3Presigner).presignGetObject(any(GetObjectPresignRequest.class));
+
+    }
+
+    @Test
+    @DisplayName("이미지를 정상 삭제한다")
+    void deleteImageSuccess() {
+        //given
+        String imageKey = "imageKey";
+        Voucher voucher = Voucher.builder().image(imageKey).build();
+
+        when(s3Client.deleteObject(any(DeleteObjectRequest.class))).thenReturn(mock(
+                DeleteObjectResponse.class));
+
+        //when
+        imageService.deleteImageWithRetry(voucher);
+
+        //then
+        verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 시, SdkClientException이 발생하는 실패는 최대 3회 재시도한다")
+    void deleteImageWithSdkClientException() {
+        //given
+        String imageKey = "imageKey";
+        Voucher voucher = Voucher.builder().image(imageKey).build();
+
+        when(s3Client.deleteObject(any(DeleteObjectRequest.class))).thenThrow(SdkClientException.class);
+
+        //when
+        assertThatThrownBy(() -> imageService.deleteImageWithRetry(voucher))
+                .isInstanceOf(ImageDeleteException.class);
+
+        //then
+        verify(s3Client, times(3)).deleteObject(any(DeleteObjectRequest.class));
+
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 시, S3Exception이 발생하는 실패는 재시도하지 않고 실패한다")
+    void deleteImageWithS3Exception() {
+        //given
+        String imageKey = "imageKey";
+        Voucher voucher = Voucher.builder().image(imageKey).build();
+
+        when(s3Client.deleteObject(any(DeleteObjectRequest.class))).thenThrow(S3Exception.class);
+
+        //when
+        assertThatThrownBy(() -> imageService.deleteImageWithRetry(voucher))
+                .isInstanceOf(ImageDeleteException.class);
+
+        //then
+        verify(s3Client, times(1)).deleteObject(any(DeleteObjectRequest.class));
+
+    }
+
+    @Test
+    @DisplayName("이미지 삭제 실패 시, 3회 재시도 중 1회만 성공하면 최종 성공한다")
+    void deleteImageSucceedWithRetry() {
+        //given
+        String imageKey = "imageKey";
+        Voucher voucher = Voucher.builder().image(imageKey).build();
+
+        when(s3Client.deleteObject(any(DeleteObjectRequest.class))).thenThrow(SdkClientException.class)
+                .thenReturn(any(DeleteObjectResponse.class));
+
+        //when
+        imageService.deleteImageWithRetry(voucher);
+
+        //then
+        verify(s3Client, times(2)).deleteObject(any(DeleteObjectRequest.class));
+
+    }
+
+}

--- a/src/test/java/seondays/shareticon/api/image/batch/S3ImageCleanupBatchProcessTest.java
+++ b/src/test/java/seondays/shareticon/api/image/batch/S3ImageCleanupBatchProcessTest.java
@@ -1,0 +1,123 @@
+package seondays.shareticon.api.image.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.persistence.EntityManager;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.BatchStatus;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.support.TransactionTemplate;
+import seondays.shareticon.api.config.IntegrationTestSupport;
+import seondays.shareticon.group.Group;
+import seondays.shareticon.group.GroupRepository;
+import seondays.shareticon.image.ImageService;
+import seondays.shareticon.user.User;
+import seondays.shareticon.user.UserRepository;
+import seondays.shareticon.voucher.Voucher;
+
+public class S3ImageCleanupBatchProcessTest extends IntegrationTestSupport {
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    private Job voucherImageCleanupJob;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @MockitoBean
+    private ImageService imageService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void setUp() {
+        Instant systemTime = Instant.parse("2025-05-01T00:00:00Z");
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+
+        when(clock.instant()).thenReturn(systemTime);
+        when(clock.getZone()).thenReturn(zoneId);
+
+    }
+
+    @Test
+    @DisplayName("배치 실행 날짜 2달 이내로 삭제된 상태인 쿠폰들을 대상으로 배치가 실행된다")
+    void executeVoucherCleanupJob() throws Exception {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        Group group = Group.builder().leaderUser(user).build();
+        groupRepository.save(group);
+
+        LocalDateTime now = LocalDateTime.now(clock);
+        LocalDateTime testDateTime = now.minusMonths(2);
+
+        Voucher expectedToBeDeleted = createDeletedVoucher(user, group, 1L, testDateTime);
+        Voucher expectedToBeSkipped = createDeletedVoucher(user, group, 2L, testDateTime.minusDays(1));
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("jobId", "test")
+                .addString("executionDate", now.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+                .toJobParameters();
+
+        //when
+        JobExecution run = jobLauncher.run(voucherImageCleanupJob, jobParameters);
+
+        //then
+        assertThat(run.getStatus()).isEqualTo(BatchStatus.COMPLETED);
+        verify(imageService, times(1)).deleteImage(any());
+        verify(imageService).deleteImage(argThat(voucher ->
+                voucher.getId().equals(expectedToBeDeleted.getId())));
+        verify(imageService, never()).deleteImage(argThat(voucher ->
+                voucher.getId().equals(expectedToBeSkipped.getId())));
+
+    }
+
+    public Voucher createDeletedVoucher(User user, Group group, Long voucherId,
+            LocalDateTime modifiedDateTime) {
+        // auditing 우회를 위해 쿼리 직접 날려서 저장하도록 설정함
+        return transactionTemplate.execute(status -> {
+            entityManager.createNativeQuery("""
+                                INSERT INTO voucher (id, user_id, group_id, is_deleted, modified_date_time)
+                                VALUES (:id, :userId, :groupId, true, :modifiedDateTime)
+                            """)
+                    .setParameter("id", voucherId)
+                    .setParameter("userId", user.getId())
+                    .setParameter("groupId", group.getId())
+                    .setParameter("modifiedDateTime", Timestamp.valueOf(modifiedDateTime))
+                    .executeUpdate();
+
+            entityManager.flush();
+            entityManager.clear();
+            return entityManager.find(Voucher.class, voucherId);
+        });
+    }
+}

--- a/src/test/java/seondays/shareticon/api/image/batch/S3ImageCleanupBatchProcessTest.java
+++ b/src/test/java/seondays/shareticon/api/image/batch/S3ImageCleanupBatchProcessTest.java
@@ -103,10 +103,10 @@ public class S3ImageCleanupBatchProcessTest extends IntegrationTestSupport {
 
         //then
         assertThat(run.getStatus()).isEqualTo(BatchStatus.COMPLETED);
-        verify(imageService, times(1)).deleteImage(any());
-        verify(imageService).deleteImage(argThat(voucher ->
+        verify(imageService, times(1)).deleteImageWithRetry(any());
+        verify(imageService).deleteImageWithRetry(argThat(voucher ->
                 voucher.getId().equals(expectedToBeDeleted.getId())));
-        verify(imageService, never()).deleteImage(argThat(voucher ->
+        verify(imageService, never()).deleteImageWithRetry(argThat(voucher ->
                 voucher.getId().equals(expectedToBeSkipped.getId())));
 
     }

--- a/src/test/java/seondays/shareticon/api/image/batch/S3ImageCleanupBatchProcessTest.java
+++ b/src/test/java/seondays/shareticon/api/image/batch/S3ImageCleanupBatchProcessTest.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import seondays.shareticon.image.ImageService;
 import seondays.shareticon.user.User;
 import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.voucher.Voucher;
+import seondays.shareticon.voucher.VoucherRepository;
 
 public class S3ImageCleanupBatchProcessTest extends IntegrationTestSupport {
 
@@ -57,6 +59,9 @@ public class S3ImageCleanupBatchProcessTest extends IntegrationTestSupport {
     @Autowired
     private TransactionTemplate transactionTemplate;
 
+    @Autowired
+    private VoucherRepository voucherRepository;
+
     @BeforeEach
     void setUp() {
         Instant systemTime = Instant.parse("2025-05-01T00:00:00Z");
@@ -65,6 +70,11 @@ public class S3ImageCleanupBatchProcessTest extends IntegrationTestSupport {
         when(clock.instant()).thenReturn(systemTime);
         when(clock.getZone()).thenReturn(zoneId);
 
+    }
+
+    @AfterEach
+    void tearDown() {
+        voucherRepository.deleteAllInBatch();
     }
 
     @Test

--- a/src/test/java/seondays/shareticon/api/image/batch/S3ImageCleanupBatchSchedulerTest.java
+++ b/src/test/java/seondays/shareticon/api/image/batch/S3ImageCleanupBatchSchedulerTest.java
@@ -1,0 +1,71 @@
+package seondays.shareticon.api.image.batch;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersInvalidException;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.repository.JobExecutionAlreadyRunningException;
+import org.springframework.batch.core.repository.JobInstanceAlreadyCompleteException;
+import org.springframework.batch.core.repository.JobRestartException;
+import seondays.shareticon.image.batch.S3ImageCleanupBatchScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class S3ImageCleanupBatchSchedulerTest {
+
+    @Mock
+    private JobLauncher jobLauncher;
+
+    @Mock
+    private Job voucherImageCleanupJob;
+
+    @Mock
+    private Clock clock;
+
+    private S3ImageCleanupBatchScheduler s3ImageCleanupBatchScheduler;
+
+    @BeforeEach
+    void setUp() {
+        s3ImageCleanupBatchScheduler = new S3ImageCleanupBatchScheduler(jobLauncher, voucherImageCleanupJob, clock);
+
+        Instant systemTime = Instant.parse("2025-05-01T00:00:00Z");
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+
+        when(clock.instant()).thenReturn(systemTime);
+        when(clock.getZone()).thenReturn(zoneId);
+
+    }
+
+    @Test
+    @DisplayName("배치 작업이 정상적으로 트리거된다")
+    void triggerBatchSchedulerJob()
+            throws JobInstanceAlreadyCompleteException, JobExecutionAlreadyRunningException, JobParametersInvalidException, JobRestartException {
+        when(jobLauncher.run(any(), any())).thenReturn(new JobExecution(1L));
+
+        s3ImageCleanupBatchScheduler.runVoucherImageCleanupJob();
+
+        ArgumentCaptor<JobParameters> captor = ArgumentCaptor.forClass(JobParameters.class);
+        verify(jobLauncher).run(eq(voucherImageCleanupJob), captor.capture());
+
+        JobParameters params = captor.getValue();
+        assertThat(params.getString("jobId")).isEqualTo("20250501");
+    }
+
+}

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
@@ -223,7 +223,7 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
 
         //when
-        Long result = voucherRepository.countByUserId(user.getId());
+        Long result = voucherRepository.countByUserIdAndIsDeletedFalse(user.getId());
 
         //then
         assertThat(result).isEqualTo(5);
@@ -238,10 +238,39 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         userRepository.save(user);
 
         //when
-        Long result = voucherRepository.countByUserId(user.getId());
+        Long result = voucherRepository.countByUserIdAndIsDeletedFalse(user.getId());
 
         //then
         assertThat(result).isZero();
+
+    }
+
+    @Test
+    @DisplayName("삭제 상태인 쿠폰은 조회에 포함되지 않는다")
+    void getAllVoucherWithNotDeleted() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
+        groupRepository.save(group);
+
+        Voucher voucher = Voucher.builder().user(user).group(group).isDeleted(true)
+                .status(VoucherStatus.AVAILABLE).build();
+        voucherRepository.save(voucher);
+
+        List<VoucherStatus> voucherStatuses = VoucherStatus.forDisplayVoucherStatus();
+
+        Pageable pageable = PageRequest.of(0, 2);
+
+        //when
+        Slice<Voucher> resultPage = voucherRepository.findAllPageWithCursorByDesc(
+                group.getId(), voucherStatuses, null, pageable);
+
+        //then
+        assertThat(resultPage.getContent()).isEmpty();
+        assertThat(resultPage.hasNext()).isFalse();
 
     }
 
@@ -249,6 +278,7 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         return Voucher.builder()
                 .user(user)
                 .group(group)
+                .isDeleted(false)
                 .status(status)
                 .build();
     }

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -298,7 +298,7 @@ class VoucherServiceTest extends IntegrationTestSupport {
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
 
-        Voucher voucher = Voucher.createAvailableStatus(user, group, voucherName, expiration);
+        Voucher voucher = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
         voucherRepository.save(voucher);
 
         //when
@@ -327,8 +327,8 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
-        Voucher voucher = Voucher.createAvailableStatus(registerUser, group, voucherName,
-                expiration);
+        Voucher voucher = Voucher.createNewVoucher(registerUser, group, voucherName,
+                "imageKey", expiration);
         voucherRepository.save(voucher);
 
         //when //then
@@ -355,8 +355,8 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
-        Voucher voucher = Voucher.createAvailableStatus(userExistInGroup, group, voucherName,
-                expiration);
+        Voucher voucher = Voucher.createNewVoucher(userExistInGroup, group, voucherName,
+                "imageKey", expiration);
         voucherRepository.save(voucher);
 
         //when //then
@@ -382,12 +382,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
-        Voucher voucher1 = Voucher.createAvailableStatus(user, group, voucherName, expiration);
-        Voucher voucher2 = Voucher.createAvailableStatus(user, group, voucherName, expiration);
-        Voucher voucher3 = Voucher.createAvailableStatus(user, group, voucherName, expiration);
-        voucher1.saveImage("image1");
-        voucher2.saveImage("image2");
-        voucher3.saveImage("image3");
+        Voucher voucher1 = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
+        Voucher voucher2 = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
+        Voucher voucher3 = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
 
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
 
@@ -458,9 +455,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
 
         LocalDate expiration = LocalDate.of(2025, 1, 1);
-        Voucher voucher1 = Voucher.createAvailableStatus(user, group, "voucher name1", expiration);
-        Voucher voucher2 = Voucher.createAvailableStatus(user, group, "voucher name2", expiration);
-        Voucher voucher3 = Voucher.createAvailableStatus(user, group, "voucher name3", expiration);
+        Voucher voucher1 = Voucher.createNewVoucher(user, group, "voucher name1", "imageKey", expiration);
+        Voucher voucher2 = Voucher.createNewVoucher(user, group, "voucher name2", "imageKey", expiration);
+        Voucher voucher3 = Voucher.createNewVoucher(user, group, "voucher name3", "imageKey", expiration);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
 
         //when //then
@@ -485,7 +482,7 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
-        Voucher voucher = Voucher.createAvailableStatus(user, group, voucherName, expiration);
+        Voucher voucher = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
         voucherRepository.save(voucher);
 
         return Stream.of(

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -106,7 +106,7 @@ class VoucherServiceTest extends IntegrationTestSupport {
         );
 
         //when
-        given(imageService.uploadImage(any()))
+        given(imageService.uploadImageWithRetry(any()))
                 .willReturn("https://test/test.jpg");
 
         given(imageService.getPresignedImageUrl(any(), any())).willReturn("presignedImageUrl");
@@ -270,7 +270,7 @@ class VoucherServiceTest extends IntegrationTestSupport {
         );
 
         //when //then
-        given(imageService.uploadImage(any()))
+        given(imageService.uploadImageWithRetry(any()))
                 .willThrow(ImageUploadException.class);
 
         assertThatThrownBy(

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Slice;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
 import seondays.shareticon.api.config.IntegrationTestSupport;
 import seondays.shareticon.exception.GroupNotFoundException;
@@ -32,6 +33,7 @@ import seondays.shareticon.exception.InvalidVoucherDeleteException;
 import seondays.shareticon.exception.UserNotFoundException;
 import seondays.shareticon.group.Group;
 import seondays.shareticon.group.GroupRepository;
+import seondays.shareticon.image.ImageService;
 import seondays.shareticon.user.User;
 import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.userGroup.UserGroup;
@@ -60,6 +62,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private UserGroupRepository userGroupRepository;
+
+    @MockitoBean
+    protected ImageService imageService;
 
     private Instant testSystemTimeInstant;
 

--- a/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/group/GroupControllerDocsTest.java
@@ -61,7 +61,7 @@ public class GroupControllerDocsTest extends RestDocsSupport {
         CreateGroupRequest request = new CreateGroupRequest("그룹 이름");
         String json = objectMapper.writeValueAsString(request);
 
-        when(groupService.createGroup(any(Long.class), any(CreateGroupRequest.class)))
+        when(groupService.registerNewGroup(any(Long.class), any(CreateGroupRequest.class)))
                 .thenReturn(GroupResponse.of(createdGroup));
 
         //when //then


### PR DESCRIPTION
## 연관 이슈
close #35 , close #36 , close #37 

## 작업 내용
- S3 쿠폰 이미지 저장 & 삭제하는 로직 개선
    - 트랜잭션 분리
    - 삭제 소프트 딜리트로 변경
- S3 쿠폰 이미지 저장 & 삭제 / 그룹 생성 작업에서 실패 시 Spring Retry를 통해 재시도하도록 구현
- 쿠폰 삭제 시, 연결된 이미지 파일이 S3에는 남아 있는 경우를 위한 정리 작업에 Spring Batch 도입

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 그룹 생성 및 이미지 업로드/삭제에 자동 재시도 기능이 추가되었습니다.
  * S3에 저장된 삭제된 바우처 이미지를 정기적으로 정리하는 배치 작업 및 스케줄러가 도입되었습니다.
  * 바우처 엔티티에 논리적 삭제(isDeleted) 기능이 추가되었습니다.

* **버그 수정**
  * 삭제된 바우처가 사용자 프로필 및 목록 조회 시 집계에서 제외됩니다.

* **리팩터링**
  * 그룹 및 바우처 생성, 이미지 처리 로직이 별도의 팩토리 및 서비스로 분리되어 관리됩니다.

* **테스트**
  * 이미지 서비스 및 S3 이미지 정리 배치의 동작을 검증하는 통합 테스트가 추가되었습니다.
  * 기존 테스트들이 신규 로직 및 메서드명 변경에 맞게 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->