### PR TITLE
asynchronous S3 image and fix Group feature

### DIFF
--- a/src/main/java/seondays/shareticon/ShareticonApplication.java
+++ b/src/main/java/seondays/shareticon/ShareticonApplication.java
@@ -3,10 +3,12 @@ package seondays.shareticon;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableRetry
 @EnableScheduling
+@EnableAsync
 @SpringBootApplication
 public class ShareticonApplication {
 

--- a/src/main/java/seondays/shareticon/group/GroupService.java
+++ b/src/main/java/seondays/shareticon/group/GroupService.java
@@ -17,7 +17,8 @@ import seondays.shareticon.group.dto.CreateGroupRequest;
 import seondays.shareticon.group.dto.GroupJoinApplyStatusChangeValidationRequest;
 import seondays.shareticon.group.dto.GroupListResponse;
 import seondays.shareticon.group.dto.GroupResponse;
-import seondays.shareticon.group.dto.GroupTitleAliasChangeValidationRequest;
+import seondays.shareticon.group.dto.LeaderIdAndGroupsValidationRequest;
+import seondays.shareticon.group.dto.UserIdAndGroupIdValidationRequest;
 import seondays.shareticon.user.User;
 import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.userGroup.UserGroup;
@@ -66,8 +67,13 @@ public class GroupService {
     @Transactional(readOnly = true)
     public List<ApplyToJoinResponse> getAllGroupPendingUserList(Long leaderUserId) {
         groupValidator.validateExistTargetUser(leaderUserId);
-
         List<Group> allGroupByLeaderUserId = groupRepository.findAllByLeaderId(leaderUserId);
+
+        LeaderIdAndGroupsValidationRequest request = LeaderIdAndGroupsValidationRequest.builder()
+                .leaderId(leaderUserId)
+                .targetGroups(allGroupByLeaderUserId).build();
+        groupValidator.validateLeaderForPendingUserList(request);
+
         return allGroupByLeaderUserId.stream()
                 .map(group -> ApplyToJoinResponse.of(group.getId(),
                         group.getGroupAlias(leaderUserId), group.getPendingMemberResponses()))
@@ -97,8 +103,8 @@ public class GroupService {
     @Transactional
     public ChangeGroupTitleAliasResponse changeGroupTitleAlias(Long userId, Long groupId,
             ChangeGroupTitleAliasRequest request) {
-        GroupTitleAliasChangeValidationRequest validationRequest =
-                GroupTitleAliasChangeValidationRequest.builder()
+        UserIdAndGroupIdValidationRequest validationRequest =
+                UserIdAndGroupIdValidationRequest.builder()
                         .requestUserId(userId)
                         .targetGroupId(groupId).build();
         groupValidator.validateGroupTitleAliasChange(validationRequest);

--- a/src/main/java/seondays/shareticon/group/GroupValidator.java
+++ b/src/main/java/seondays/shareticon/group/GroupValidator.java
@@ -27,6 +27,12 @@ public class GroupValidator {
         validateExistTargetUser(request.targetUserId());
     }
 
+    public void validateLeaderForPendingUserList(LeaderIdAndGroupsValidationRequest request) {
+        for (Group g : request.targetGroups()) {
+            validateLeader(request.leaderId(), g);
+        }
+    }
+
     public void validateExistTargetUser(Long targetUserId) {
         if (!userRepository.existsById(targetUserId)) {
             throw new UserNotFoundException();

--- a/src/main/java/seondays/shareticon/group/GroupValidator.java
+++ b/src/main/java/seondays/shareticon/group/GroupValidator.java
@@ -40,7 +40,7 @@ public class GroupValidator {
         if (!leaderId.equals(group.getLeaderUser().getId())) {
             throw new InvalidAcceptGroupJoinApplyException();
         }
-        if (!userGroupRepository.existsByUserIdAndGroupId(leaderId, group.getId())) {
+        if (!userGroupRepository.existsByUserIdAndGroupIdAndJoinStatus(leaderId, group.getId(), JoinStatus.JOINED)) {
             throw new InvalidAcceptGroupJoinApplyException();
         }
     }

--- a/src/main/java/seondays/shareticon/group/GroupValidator.java
+++ b/src/main/java/seondays/shareticon/group/GroupValidator.java
@@ -6,7 +6,8 @@ import seondays.shareticon.exception.GroupNotFoundException;
 import seondays.shareticon.exception.InvalidAcceptGroupJoinApplyException;
 import seondays.shareticon.exception.UserNotFoundException;
 import seondays.shareticon.group.dto.GroupJoinApplyStatusChangeValidationRequest;
-import seondays.shareticon.group.dto.GroupTitleAliasChangeValidationRequest;
+import seondays.shareticon.group.dto.LeaderIdAndGroupsValidationRequest;
+import seondays.shareticon.group.dto.UserIdAndGroupIdValidationRequest;
 import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.userGroup.UserGroupRepository;
 
@@ -18,11 +19,12 @@ public class GroupValidator {
     private final UserGroupRepository userGroupRepository;
     private final GroupRepository groupRepository;
 
-    public void validateGroupTitleAliasChange(GroupTitleAliasChangeValidationRequest request) {
+    public void validateGroupTitleAliasChange(UserIdAndGroupIdValidationRequest request) {
         validateUserAndGroupExist(request.requestUserId(), request.targetGroupId());
     }
 
-    public void validateGroupJoinApplyStatusChange(GroupJoinApplyStatusChangeValidationRequest request) {
+    public void validateGroupJoinApplyStatusChange(
+            GroupJoinApplyStatusChangeValidationRequest request) {
         validateLeader(request.leaderId(), request.targetGroup());
         validateExistTargetUser(request.targetUserId());
     }

--- a/src/main/java/seondays/shareticon/group/dto/LeaderIdAndGroupsValidationRequest.java
+++ b/src/main/java/seondays/shareticon/group/dto/LeaderIdAndGroupsValidationRequest.java
@@ -1,0 +1,11 @@
+package seondays.shareticon.group.dto;
+
+import java.util.List;
+import lombok.Builder;
+import seondays.shareticon.group.Group;
+
+@Builder
+public record LeaderIdAndGroupsValidationRequest (Long leaderId,
+                                                  List<Group> targetGroups){
+
+}

--- a/src/main/java/seondays/shareticon/group/dto/UserIdAndGroupIdValidationRequest.java
+++ b/src/main/java/seondays/shareticon/group/dto/UserIdAndGroupIdValidationRequest.java
@@ -1,0 +1,9 @@
+package seondays.shareticon.group.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserIdAndGroupIdValidationRequest(Long requestUserId,
+                                                Long targetGroupId) {
+
+}

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import seondays.shareticon.exception.ImageDeleteException;
@@ -98,6 +99,7 @@ public class ImageService {
             maxAttempts = 3,
             backoff = @Backoff(delayExpression = "${retry.S3-Image-service.delay}", multiplier = 2)
     )
+    @Async
     public void deleteImageWithRetry(Voucher voucher) {
         String key = voucher.getImage();
 

--- a/src/main/java/seondays/shareticon/image/ImageService.java
+++ b/src/main/java/seondays/shareticon/image/ImageService.java
@@ -93,13 +93,17 @@ public class ImageService {
         }
     }
 
+    @Async
+    public void deleteImageAsync(Voucher voucher) {
+        deleteImageWithRetry(voucher);
+    }
+
     @Retryable(
             retryFor = {SdkClientException.class},
             noRetryFor = {S3Exception.class},
             maxAttempts = 3,
             backoff = @Backoff(delayExpression = "${retry.S3-Image-service.delay}", multiplier = 2)
     )
-    @Async
     public void deleteImageWithRetry(Voucher voucher) {
         String key = voucher.getImage();
 

--- a/src/main/java/seondays/shareticon/user/UserService.java
+++ b/src/main/java/seondays/shareticon/user/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
     public UserProfileResponse getUserProfile(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
-        Long joinGroupCount = userGroupRepository.countByUserId(userId);
+        Long joinGroupCount = userGroupRepository.countByUserIdAndJoined(userId);
 
         Long ownedVoucherCount = voucherRepository.countByUserIdAndIsDeletedFalse(userId);
 

--- a/src/main/java/seondays/shareticon/userGroup/UserGroupRepository.java
+++ b/src/main/java/seondays/shareticon/userGroup/UserGroupRepository.java
@@ -11,7 +11,7 @@ import seondays.shareticon.group.dto.GroupListResponse;
 @Repository
 public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
 
-    boolean existsByUserIdAndGroupId(Long userId, Long groupId);
+    boolean existsByUserIdAndGroupIdAndJoinStatus(Long userId, Long groupId, JoinStatus status);
 
     @Query("""
             SELECT COUNT(ug)

--- a/src/main/java/seondays/shareticon/userGroup/UserGroupRepository.java
+++ b/src/main/java/seondays/shareticon/userGroup/UserGroupRepository.java
@@ -13,16 +13,20 @@ public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
 
     boolean existsByUserIdAndGroupId(Long userId, Long groupId);
 
-    Long countByUserId(Long userId);
+    @Query("""
+            SELECT COUNT(ug)
+            FROM UserGroup ug
+            WHERE ug.user.id = :userId AND ug.joinStatus = 'JOINED'""")
+    Long countByUserIdAndJoined(Long userId);
 
     Optional<UserGroup> findByUserIdAndGroupId(Long userId, Long groupId);
 
     @Query("""
-            select ug
-              from UserGroup ug
+            SELECT ug
+              FROM UserGroup ug
               JOIN FETCH ug.user
-              where ug.group.leaderUser.id = :leaderId
-                and ug.joinStatus = :status
+              WHERE ug.group.leaderUser.id = :leaderId
+                AND ug.joinStatus = :status
                 """)
     List<UserGroup> findByLeaderAndJoinStatus(Long leaderId, JoinStatus status);
 
@@ -39,5 +43,6 @@ public interface UserGroupRepository extends JpaRepository<UserGroup, Long> {
             AND ug.joinStatus in :status
             GROUP BY g.id, ug.groupTitleAlias
             """)
-    List<GroupListResponse> findGroupsWithMemberCountByUserIdAndStatus(Long userId, List<JoinStatus> status);
+    List<GroupListResponse> findGroupsWithMemberCountByUserIdAndStatus(Long userId,
+            List<JoinStatus> status);
 }

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -93,7 +93,7 @@ public class VoucherService {
 
         voucher.delete();
 
-        imageService.deleteImageWithRetry(voucher);
+        imageService.deleteImageAsync(voucher);
     }
 
     /**

--- a/src/main/java/seondays/shareticon/voucher/VoucherValidator.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherValidator.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import seondays.shareticon.exception.InvalidAccessVoucherException;
 import seondays.shareticon.exception.InvalidVoucherDeleteException;
 import seondays.shareticon.exception.InvalidVoucherExpireException;
+import seondays.shareticon.group.JoinStatus;
 import seondays.shareticon.user.User;
 import seondays.shareticon.userGroup.UserGroupRepository;
 import seondays.shareticon.voucher.dto.VoucherCreationValidationRequest;
@@ -39,7 +40,7 @@ public class VoucherValidator {
     }
 
     private void validateUserAndVoucherInGroup(Long userId, Long groupId, Voucher voucher) {
-        if (!userGroupRepository.existsByUserIdAndGroupId(userId, groupId)) {
+        if (!userGroupRepository.existsByUserIdAndGroupIdAndJoinStatus(userId, groupId, JoinStatus.JOINED)) {
             throw new InvalidVoucherDeleteException();
         }
         if (!voucher.getGroup().getId().equals(groupId)) {
@@ -48,7 +49,7 @@ public class VoucherValidator {
     }
 
     private void validateUserInGroup(Long userId, Long groupId) {
-        if (!userGroupRepository.existsByUserIdAndGroupId(userId, groupId)) {
+        if (!userGroupRepository.existsByUserIdAndGroupIdAndJoinStatus(userId, groupId, JoinStatus.JOINED)) {
             throw new InvalidAccessVoucherException();
         }
     }

--- a/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/group/GroupServiceTest.java
@@ -422,6 +422,31 @@ public class GroupServiceTest extends IntegrationTestSupport {
     }
 
     @Test
+    @DisplayName("정상적으로 본인의 그룹에 JOINED 중인 리더만 그룹 가입 신청 목록을 조회 가능하다")
+    void getAllApplyToJoinListWithJoinedLeader() {
+        //given
+        User leaderUser = User.builder().build();
+        User pendingUser = User.builder().build();
+        userRepository.saveAll(List.of(leaderUser, pendingUser));
+
+        String inviteCode = "ABC";
+        String title = "test title";
+        Group group = Group.createNewGroup(leaderUser, inviteCode, title);
+        groupRepository.save(group);
+
+        UserGroup userGroup1 = UserGroup.builder().user(leaderUser).group(group)
+                .joinStatus(JoinStatus.WITHDRAWN).build();
+        UserGroup userGroup2 = UserGroup.builder().user(pendingUser).group(group)
+                .joinStatus(JoinStatus.PENDING).build();
+        userGroupRepository.saveAll(List.of(userGroup1, userGroup2));
+
+        //when //then
+        assertThatThrownBy(() -> groupService.getAllGroupPendingUserList(leaderUser.getId()))
+                .isInstanceOf(InvalidAcceptGroupJoinApplyException.class);
+
+    }
+
+    @Test
     @DisplayName("그룹 신청 내역을 조회하는 유저는 DB에 저장된 회원이어야 한다")
     void getAllApplyToJoinListWithoutExistUser() {
         //given

--- a/src/test/java/seondays/shareticon/api/user/UserServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/user/UserServiceTest.java
@@ -12,6 +12,7 @@ import seondays.shareticon.api.config.IntegrationTestSupport;
 import seondays.shareticon.exception.UserNotFoundException;
 import seondays.shareticon.group.Group;
 import seondays.shareticon.group.GroupRepository;
+import seondays.shareticon.group.JoinStatus;
 import seondays.shareticon.user.User;
 import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.user.UserService;
@@ -113,7 +114,7 @@ public class UserServiceTest extends IntegrationTestSupport {
     }
 
     private UserGroup linkUserWithGroup(User user, Group group) {
-        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
+        UserGroup userGroup = UserGroup.builder().user(user).joinStatus(JoinStatus.JOINED).group(group).build();
         userGroupRepository.save(userGroup);
         return userGroup;
     }

--- a/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
@@ -241,16 +241,11 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         String inviteCode2 = "DEF";
         Group group2 = createTestGroup(inviteCode2);
 
-        String inviteCode3 = "GHI";
-        Group group3 = createTestGroup(inviteCode3);
-
-        String inviteCode4 = "JKL";
-        Group group4 = createTestGroup(inviteCode4);
-        groupRepository.saveAll(List.of(group, group2, group3, group4));
+        groupRepository.saveAll(List.of(group, group2));
 
         UserGroup userGroup = UserGroup.builder().joinStatus(JoinStatus.JOINED).user(user).group(group).build();
         UserGroup userGroup2 = UserGroup.builder().joinStatus(JoinStatus.WITHDRAWN).user(user).group(group2).build();
-        UserGroup userGroup3 = UserGroup.builder().joinStatus(JoinStatus.REJECTED).user(user).group(group2).build();
+        UserGroup userGroup3 = UserGroup.builder().joinStatus(JoinStatus.REJECTED).user(user).group(group).build();
         UserGroup userGroup4 = UserGroup.builder().joinStatus(JoinStatus.PENDING).user(user).group(group2).build();
         userGroupRepository.saveAll(List.of(userGroup, userGroup2, userGroup3, userGroup4));
 

--- a/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.groups.Tuple.tuple;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.hibernate.mapping.Join;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -217,15 +216,49 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         Group group2 = createTestGroup(inviteCode2);
         groupRepository.saveAll(List.of(group, group2));
 
-        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
-        UserGroup userGroup2 = UserGroup.builder().user(user).group(group2).build();
+        UserGroup userGroup = UserGroup.builder().joinStatus(JoinStatus.JOINED).user(user).group(group).build();
+        UserGroup userGroup2 = UserGroup.builder().joinStatus(JoinStatus.JOINED).user(user).group(group2).build();
         userGroupRepository.saveAll(List.of(userGroup, userGroup2));
 
         //when
-        Long result = userGroupRepository.countByUserId(user.getId());
+        Long result = userGroupRepository.countByUserIdAndJoined(user.getId());
 
         //then
         assertThat(result).isEqualTo(2);
+
+    }
+
+    @Test
+    @DisplayName("그룹 가입 상태가 JOINED가 아닌 경우에는 전체 그룹 수에 포함되지 않는다")
+    void getUserJoinGroupCountWithJoined() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
+
+        String inviteCode2 = "DEF";
+        Group group2 = createTestGroup(inviteCode2);
+
+        String inviteCode3 = "GHI";
+        Group group3 = createTestGroup(inviteCode3);
+
+        String inviteCode4 = "JKL";
+        Group group4 = createTestGroup(inviteCode4);
+        groupRepository.saveAll(List.of(group, group2, group3, group4));
+
+        UserGroup userGroup = UserGroup.builder().joinStatus(JoinStatus.JOINED).user(user).group(group).build();
+        UserGroup userGroup2 = UserGroup.builder().joinStatus(JoinStatus.WITHDRAWN).user(user).group(group2).build();
+        UserGroup userGroup3 = UserGroup.builder().joinStatus(JoinStatus.REJECTED).user(user).group(group2).build();
+        UserGroup userGroup4 = UserGroup.builder().joinStatus(JoinStatus.PENDING).user(user).group(group2).build();
+        userGroupRepository.saveAll(List.of(userGroup, userGroup2, userGroup3, userGroup4));
+
+        //when
+        Long result = userGroupRepository.countByUserIdAndJoined(user.getId());
+
+        //then
+        assertThat(result).isEqualTo(1);
 
     }
 
@@ -237,7 +270,7 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         userRepository.save(user);
 
         //when
-        Long result = userGroupRepository.countByUserId(user.getId());
+        Long result = userGroupRepository.countByUserIdAndJoined(user.getId());
 
         //then
         assertThat(result).isZero();

--- a/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/userGroup/UserGroupRepositoryTest.java
@@ -41,11 +41,11 @@ public class UserGroupRepositoryTest extends RepositoryTestSupport {
         Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        UserGroup userGroup = UserGroup.builder().user(user).group(group).build();
+        UserGroup userGroup = UserGroup.builder().user(user).joinStatus(JoinStatus.JOINED).group(group).build();
         userGroupRepository.save(userGroup);
 
         //when
-        boolean result = userGroupRepository.existsByUserIdAndGroupId(user.getId(), group.getId());
+        boolean result = userGroupRepository.existsByUserIdAndGroupIdAndJoinStatus(user.getId(), group.getId(), JoinStatus.JOINED);
 
         //then
         assertThat(result).isTrue();

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -511,7 +511,9 @@ class VoucherServiceTest extends IntegrationTestSupport {
     }
 
     private UserGroup linkUserWithGroup(User user, Group group, String alias) {
-        UserGroup userGroup = UserGroup.builder().user(user).group(group).groupTitleAlias(alias).build();
+        UserGroup userGroup = UserGroup.builder()
+                .user(user).group(group).groupTitleAlias(alias).joinStatus(JoinStatus.JOINED)
+                .build();
         userGroupRepository.save(userGroup);
         return userGroup;
     }


### PR DESCRIPTION
## 연관 이슈
close #40, close #41

## 작업 내용
- S3 쿠폰 이미지 삭제 시 별도의 스레드로 비동기 작동하도록 변경
- 그룹 도메인 관련 기능에서 발견된 문제점해결
    - 유저가 가입한 그룹을 정상적으로 카운팅하도록 로직 수정
    - 그룹 가입 신청 내역 조회 시, 해당 유저가 리더 유저가 맞는지 UserGroup을 통해 한 번 더 확인하는 로직 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이미지 삭제 작업이 비동기로 처리되어, 서비스의 응답성이 향상되었습니다.

* **버그 수정**
  * 그룹 리더 및 사용자-그룹 관계 검증 시, 실제로 가입(Join)된 상태만을 정확히 반영하도록 개선되었습니다.
  * 사용자 프로필의 그룹 수 집계가 실제 가입된 그룹만 포함하도록 수정되었습니다.

* **테스트**
  * 그룹 리더가 탈퇴 상태일 때 대기 중인 가입 요청을 조회하면 예외가 발생하는 케이스가 추가되었습니다.
  * 그룹 가입 상태별 집계 및 존재 여부 확인 테스트가 보강되었습니다.

* **리팩터**
  * 그룹 및 사용자-그룹 검증 로직이 명확하게 분리되고, 검증 요청 객체가 세분화되었습니다.

* **기타**
  * Spring 비동기 기능이 활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->