### PR TITLE
Voucher View Filtering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,29 @@ dependencies {
 
 	// prometheus
 	implementation("io.micrometer:micrometer-registry-prometheus")
+
+	// openfeign querydsl
+	implementation("io.github.openfeign.querydsl:querydsl-jpa:7.0")
+	annotationProcessor("io.github.openfeign.querydsl:querydsl-apt:7.0:jakarta")
+
+	def generated = "$buildDir/generated/querydsl"
+
+	tasks.withType(JavaCompile).configureEach {
+		options.generatedSourceOutputDirectory.set(file(generated))
+	}
+
+	sourceSets {
+		main {
+			java {
+				srcDirs += [generated]
+			}
+		}
+	}
+
+	clean {
+		delete file(generated)
+	}
+
 }
 
 tasks.named('test') {

--- a/src/main/java/seondays/shareticon/config/QueryDslConfig.java
+++ b/src/main/java/seondays/shareticon/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package seondays.shareticon.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/seondays/shareticon/exception/handler/CustomExceptionHandler.java
+++ b/src/main/java/seondays/shareticon/exception/handler/CustomExceptionHandler.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.exception.handler;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -151,6 +152,14 @@ public class CustomExceptionHandler {
         log.error(String.valueOf(e));
 
         return createExceptionResponse(message, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CustomExceptionResponse> handleConstraintViolationException(
+            ConstraintViolationException e) {
+        log.error(String.valueOf(e));
+
+        return createExceptionResponse(e.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)

--- a/src/main/java/seondays/shareticon/voucher/VoucherController.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherController.java
@@ -3,13 +3,13 @@ package seondays.shareticon.voucher;
 import jakarta.validation.Valid;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -56,10 +56,13 @@ public class VoucherController {
             @AuthenticationPrincipal CustomOAuth2User userDetails,
             @PathVariable("groupId") Long groupId,
             @RequestParam(required = false) Long cursorId,
-            @RequestParam(defaultValue = "10") int pageSize) {
+            @RequestParam(defaultValue = "10") int pageSize,
+            @ModelAttribute VoucherFilterCondition condition) {
         Long userId = userDetails.getId();
+
         SliceResponse<VoucherListResponse> response = voucherService.getAllVoucher(userId,
-                groupId, cursorId, pageSize);
+                groupId, cursorId, pageSize, condition);
+
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/seondays/shareticon/voucher/VoucherController.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherController.java
@@ -60,7 +60,7 @@ public class VoucherController {
             @AuthenticationPrincipal CustomOAuth2User userDetails,
             @PathVariable("groupId") Long groupId,
             @RequestParam(required = false) Long cursorId,
-            @Valid @RequestParam(defaultValue = "10") @Min(1) @Max(20) int pageSize,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(20) int pageSize,
             @ModelAttribute VoucherFilterCondition condition) {
         Long userId = userDetails.getId();
 

--- a/src/main/java/seondays/shareticon/voucher/VoucherController.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherController.java
@@ -1,12 +1,15 @@
 package seondays.shareticon.voucher;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -24,6 +27,7 @@ import seondays.shareticon.voucher.dto.CreateVoucherRequest;
 import seondays.shareticon.voucher.dto.VoucherListResponse;
 import seondays.shareticon.voucher.dto.VouchersResponse;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/vouchers")
@@ -56,7 +60,7 @@ public class VoucherController {
             @AuthenticationPrincipal CustomOAuth2User userDetails,
             @PathVariable("groupId") Long groupId,
             @RequestParam(required = false) Long cursorId,
-            @RequestParam(defaultValue = "10") int pageSize,
+            @Valid @RequestParam(defaultValue = "10") @Min(1) @Max(20) int pageSize,
             @ModelAttribute VoucherFilterCondition condition) {
         Long userId = userDetails.getId();
 

--- a/src/main/java/seondays/shareticon/voucher/VoucherFilterCondition.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherFilterCondition.java
@@ -1,0 +1,15 @@
+package seondays.shareticon.voucher;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.format.annotation.DateTimeFormat;
+
+public record VoucherFilterCondition(List<VoucherStatus> voucherStatuses,
+                                     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDay,
+                                     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDay) {
+
+    public static VoucherFilterCondition of(List<VoucherStatus> voucherStatuses, LocalDate startDay, LocalDate endDay) {
+        return new VoucherFilterCondition(voucherStatuses, startDay, endDay);
+    }
+
+}

--- a/src/main/java/seondays/shareticon/voucher/VoucherQueryDslRepository.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherQueryDslRepository.java
@@ -1,0 +1,11 @@
+package seondays.shareticon.voucher;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import seondays.shareticon.voucher.dto.VoucherWithWishListResponse;
+
+public interface VoucherQueryDslRepository {
+
+    Slice<VoucherWithWishListResponse> searchVoucher(Long userId, Long groupId,
+            VoucherFilterCondition voucherFilterCondition, Long cursorId, Pageable pageable);
+}

--- a/src/main/java/seondays/shareticon/voucher/VoucherRepository.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherRepository.java
@@ -1,34 +1,12 @@
 package seondays.shareticon.voucher;
 
-import java.util.List;
 import java.util.Optional;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import seondays.shareticon.voucher.dto.VoucherWithWishListResponse;
 
 @Repository
-public interface VoucherRepository extends JpaRepository<Voucher, Long> {
-
-    @Query("""
-              select new seondays.shareticon.voucher.dto.VoucherWithWishListResponse(
-                          v,
-                          case when w.isActive = true then true else false end)
-              from Voucher v
-              left join WishList w on v = w.voucher and w.user.id = :userId
-              where v.group.id= :groupId
-              and v.status in :voucherStatuses
-              and (:cursorId is null or v.id < :cursorId)
-              and v.isDeleted = false
-              order by v.id DESC
-            """)
-    Slice<VoucherWithWishListResponse> findAllPageWithCursorByDesc(
-            @Param("userId") Long userId, @Param("groupId") Long groupId,
-            @Param("voucherStatuses") List<VoucherStatus> voucherStatuses,
-            @Param("cursorId") Long cursorId, Pageable pageable);
+public interface VoucherRepository extends JpaRepository<Voucher, Long>, VoucherQueryDslRepository {
 
     Long countByUserIdAndIsDeletedFalse(Long userId);
 

--- a/src/main/java/seondays/shareticon/voucher/VoucherRepositoryImpl.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherRepositoryImpl.java
@@ -1,0 +1,79 @@
+package seondays.shareticon.voucher;
+
+import static seondays.shareticon.voucher.QVoucher.*;
+import static seondays.shareticon.wishlist.QWishList.*;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import seondays.shareticon.voucher.dto.QVoucherWithWishListResponse;
+import seondays.shareticon.voucher.dto.VoucherWithWishListResponse;
+
+@RequiredArgsConstructor
+public class VoucherRepositoryImpl implements VoucherQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final Clock clock;
+
+    @Override
+    public Slice<VoucherWithWishListResponse> searchVoucher(Long userId, Long groupId,
+            VoucherFilterCondition voucherFilterCondition, Long cursorId, Pageable pageable) {
+
+        int pageSize = pageable.getPageSize();
+
+        List<VoucherWithWishListResponse> result = jpaQueryFactory.select(
+                        new QVoucherWithWishListResponse(
+                                voucher,
+                                wishList.id.isNotNull()
+                        ))
+                .from(voucher)
+                .leftJoin(wishList)
+                .on(wishList.voucher.eq(voucher).and(wishList.user.id.eq(userId)))
+                .where(
+                        expirationBetween(voucherFilterCondition.startDay(),
+                                voucherFilterCondition.endDay()),
+                        voucherStatusIn(voucherFilterCondition.voucherStatuses()),
+                        voucher.isDeleted.isFalse(),
+                        cursorCondition(cursorId)
+                )
+                .orderBy(voucher.id.desc())
+                .limit(pageSize + 1)
+                .fetch();
+
+        boolean hasNext = result.size() > pageSize;
+
+        if (hasNext) {
+            result.remove(pageSize);
+        }
+
+        return new SliceImpl<>(result, pageable, hasNext);
+    }
+
+    private BooleanExpression cursorCondition(Long cursorId) {
+        return cursorId == null ? null : voucher.id.lt(cursorId);
+    }
+
+    private BooleanExpression expirationBetween(LocalDate startDay, LocalDate endDay) {
+        LocalDate defaultStartDay = LocalDate.now(clock);
+        LocalDate defaultEndDay = defaultStartDay.plusDays(30);
+
+        LocalDate actualStartDay = startDay == null ? defaultStartDay : startDay;
+        LocalDate actualEndDay = endDay == null ? defaultEndDay : endDay;
+
+        return voucher.expiration.between(actualStartDay, actualEndDay);
+    }
+
+    private BooleanExpression voucherStatusIn(List<VoucherStatus> voucherStatuses) {
+        List<VoucherStatus> targetStatuses = Optional.ofNullable(voucherStatuses)
+                .filter(list -> !list.isEmpty())
+                .orElse(VoucherStatus.forDisplayVoucherStatus());
+        return voucher.status.in(targetStatuses);
+    }
+}

--- a/src/main/java/seondays/shareticon/voucher/VoucherRepositoryImpl.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherRepositoryImpl.java
@@ -31,7 +31,7 @@ public class VoucherRepositoryImpl implements VoucherQueryDslRepository {
         List<VoucherWithWishListResponse> result = jpaQueryFactory.select(
                         new QVoucherWithWishListResponse(
                                 voucher,
-                                wishList.id.isNotNull()
+                                wishList.isActive.isTrue()
                         ))
                 .from(voucher)
                 .leftJoin(wishList)

--- a/src/main/java/seondays/shareticon/voucher/VoucherRepositoryImpl.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherRepositoryImpl.java
@@ -37,6 +37,7 @@ public class VoucherRepositoryImpl implements VoucherQueryDslRepository {
                 .leftJoin(wishList)
                 .on(wishList.voucher.eq(voucher).and(wishList.user.id.eq(userId)))
                 .where(
+                        voucher.group.id.eq(groupId),
                         expirationBetween(voucherFilterCondition.startDay(),
                                 voucherFilterCondition.endDay()),
                         voucherStatusIn(voucherFilterCondition.voucherStatuses()),

--- a/src/main/java/seondays/shareticon/voucher/VoucherService.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherService.java
@@ -102,15 +102,14 @@ public class VoucherService {
      * @return
      */
     public SliceResponse<VoucherListResponse> getAllVoucher(Long userId, Long groupId, Long cursorId,
-            int size) {
+            int size, VoucherFilterCondition condition) {
         UserGroup userGroup = userGroupRepository.findByUserIdAndGroupId(userId, groupId)
                 .orElseThrow(InvalidAccessException::new);
 
-        Pageable pageable = PageRequest.of(0, size);
+        Pageable pageable = PageRequest.ofSize(size);
 
         Slice<VoucherWithWishListResponse> vouchers =
-                voucherRepository.findAllPageWithCursorByDesc(userId, groupId,
-                VoucherStatus.forDisplayVoucherStatus(), cursorId, pageable);
+                voucherRepository.searchVoucher(userId, groupId, condition, cursorId, pageable);
 
         List<VouchersResponse> vouchersResponseList = vouchers.stream()
                 .map(voucher -> {

--- a/src/main/java/seondays/shareticon/voucher/VoucherStatus.java
+++ b/src/main/java/seondays/shareticon/voucher/VoucherStatus.java
@@ -13,7 +13,7 @@ public enum VoucherStatus {
     private final String discription;
 
     public static List<VoucherStatus> forDisplayVoucherStatus() {
-        return List.of(USED, AVAILABLE, EXPIRED);
+        return List.of(USED, AVAILABLE);
     }
 
     public void validateVoucherStatusExpired() {

--- a/src/main/java/seondays/shareticon/voucher/dto/CreateVoucherRequest.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/CreateVoucherRequest.java
@@ -1,6 +1,6 @@
 package seondays.shareticon.voucher.dto;
 
-import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -11,7 +11,7 @@ public record CreateVoucherRequest(
         @NotEmpty(message = "쿠폰 이름을 포함해야 합니다")
         String voucherName,
         @NotNull(message = "쿠폰의 만료 일자를 포함해야 합니다")
-        @Future(message = "쿠폰의 만료 일자는 오늘보다 이전 날짜로 지정할 수 없습니다")
+        @FutureOrPresent(message = "쿠폰의 만료 일자는 오늘보다 이전 날짜로 지정할 수 없습니다")
         LocalDate expiration) {
 
 }

--- a/src/main/java/seondays/shareticon/voucher/dto/VoucherWithWishListResponse.java
+++ b/src/main/java/seondays/shareticon/voucher/dto/VoucherWithWishListResponse.java
@@ -1,5 +1,6 @@
 package seondays.shareticon.voucher.dto;
 
+import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDate;
 import seondays.shareticon.voucher.Voucher;
 import seondays.shareticon.voucher.VoucherStatus;
@@ -14,6 +15,7 @@ public record VoucherWithWishListResponse(
         boolean isWishList
 ) {
 
+    @QueryProjection
     public VoucherWithWishListResponse(Voucher voucher, boolean isWishList){
         this(
                 voucher.getId(),

--- a/src/test/java/seondays/shareticon/api/config/RepositoryTestSupport.java
+++ b/src/test/java/seondays/shareticon/api/config/RepositoryTestSupport.java
@@ -4,10 +4,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import seondays.shareticon.config.AuditingConfig;
+import seondays.shareticon.config.QueryDslConfig;
 
 @ActiveProfiles("test")
 @DataJpaTest
-@Import(AuditingConfig.class)
+@Import({AuditingConfig.class, QueryDslConfig.class, TestValidatorConfig.class})
 public abstract class RepositoryTestSupport {
 
 }

--- a/src/test/java/seondays/shareticon/api/config/TestQueryDslConfig.java
+++ b/src/test/java/seondays/shareticon/api/config/TestQueryDslConfig.java
@@ -1,0 +1,21 @@
+package seondays.shareticon.api.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class TestQueryDslConfig  {
+
+    private final EntityManager entityManager;
+
+    public TestQueryDslConfig(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
@@ -4,21 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.web.multipart.MultipartFile;
 import seondays.shareticon.api.config.ControllerTestSupport;
 import seondays.shareticon.group.Group;
@@ -28,6 +22,7 @@ import seondays.shareticon.user.dto.UserOAuth2Dto;
 import seondays.shareticon.userGroup.UserGroup;
 import seondays.shareticon.utils.SliceResponse;
 import seondays.shareticon.voucher.Voucher;
+import seondays.shareticon.voucher.VoucherFilterCondition;
 import seondays.shareticon.voucher.VoucherStatus;
 import seondays.shareticon.voucher.dto.CreateVoucherRequest;
 import seondays.shareticon.voucher.dto.VoucherListResponse;
@@ -40,6 +35,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oauth2Login;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class VoucherControllerTest extends ControllerTestSupport {
 
@@ -94,7 +90,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(status().isCreated())
                 .andExpect(header().string("Location", "/vouchers/1"))
                 .andExpect(jsonPath("$.id").value(1L))
                 .andExpect(jsonPath("$.status").value("AVAILABLE"))
@@ -145,7 +141,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("그룹 ID를 포함해야 합니다"))
                 .andExpect(jsonPath("$.code").value("400"));
 
@@ -192,7 +188,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("쿠폰 이름을 포함해야 합니다"))
                 .andExpect(jsonPath("$.code").value("400"));
 
@@ -239,7 +235,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("쿠폰의 만료 일자를 포함해야 합니다"))
                 .andExpect(jsonPath("$.code").value("400"));
 
@@ -290,7 +286,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                     Exception resolvedException = result.getResolvedException();
                     resolvedException.printStackTrace();
                 })
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("쿠폰의 만료 일자는 오늘보다 이전 날짜로 지정할 수 없습니다"))
                 .andExpect(jsonPath("$.code").value("400"));
 
@@ -311,7 +307,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk());
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -329,7 +325,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"));
     }
 
@@ -348,12 +344,75 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"));
     }
 
     @Test
-    @DisplayName("페이징을 포함하여 그룹에 등록된 전체 쿠폰을 조회한다")
+    @DisplayName("필터 조건과 페이지 정보 모두 포함하여 그룹에 등록된 전체 쿠폰을 조회한다")
+    void getAllVoucherInGroupPageInfoAndFilterCondition() throws Exception {
+        //given
+        Long groupId = 1L;
+        Long userId = mockUser.getId();
+        Long voucherId = 1L;
+        Long cursorId = 1L;
+        int pageSize = 1;
+        boolean hasNext = false;
+        String mockPresignedUrl = "mockPresignedUrl";
+
+        User user = User.builder()
+                .id(userId)
+                .build();
+        Voucher voucher = Voucher.builder()
+                .id(voucherId)
+                .image("www.image.com")
+                .user(user)
+                .status(VoucherStatus.AVAILABLE)
+                .build();
+        Group group = Group.builder()
+                .id(groupId)
+                .inviteCode("InviteCode")
+                .build();
+        UserGroup userGroup = UserGroup.builder()
+                .user(user)
+                .group(group)
+                .groupTitleAlias("나의 그룹 이름")
+                .build();
+        VoucherListResponse mockResponse = VoucherListResponse.of(
+                List.of(VouchersResponse.withWishList(voucher, mockPresignedUrl, false)),
+                userGroup);
+
+        SliceResponse<VoucherListResponse> mockSlice = SliceResponse.of(mockResponse, hasNext,
+                pageSize);
+
+        VoucherFilterCondition emptyCondition = VoucherFilterCondition.of(
+                List.of(VoucherStatus.AVAILABLE),
+                LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 31));
+
+        when(voucherService.getAllVoucher(eq(mockUser.getId()), eq(groupId), eq(cursorId),
+                eq(pageSize), eq(emptyCondition))).thenReturn(mockSlice);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/vouchers/{groupId}", groupId)
+                                .param("cursorId", cursorId.toString())
+                                .param("pageSize", String.valueOf(pageSize))
+                                .param("voucherStatuses", "AVAILABLE")
+                                .param("startDay", "2025-01-01")
+                                .param("endDay", "2025-01-31")
+                                .with(csrf())
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isNotEmpty())
+                .andExpect(jsonPath("$.size").value(pageSize))
+                .andExpect(jsonPath("$.hasNext").value(hasNext));
+
+    }
+
+    @Test
+    @DisplayName("필터 조건은 없고, 페이지 정보는 포함해서 그룹에 등록된 전체 쿠폰을 조회한다")
     void getAllVoucherInGroup() throws Exception {
         //given
         Long groupId = 1L;
@@ -383,13 +442,16 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 .groupTitleAlias("나의 그룹 이름")
                 .build();
         VoucherListResponse mockResponse = VoucherListResponse.of(
-                List.of(VouchersResponse.withWishList(voucher, mockPresignedUrl, false)), userGroup);
+                List.of(VouchersResponse.withWishList(voucher, mockPresignedUrl, false)),
+                userGroup);
 
         SliceResponse<VoucherListResponse> mockSlice = SliceResponse.of(mockResponse, hasNext,
                 pageSize);
 
+        VoucherFilterCondition mockFilterCondition = VoucherFilterCondition.of(null, null, null);
+
         when(voucherService.getAllVoucher(eq(mockUser.getId()), eq(groupId), eq(cursorId),
-                eq(pageSize))).thenReturn(mockSlice);
+                eq(pageSize), eq(mockFilterCondition))).thenReturn(mockSlice);
 
         //when //then
         mockMvc.perform(
@@ -400,15 +462,15 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isNotEmpty())
                 .andExpect(jsonPath("$.size").value(pageSize))
                 .andExpect(jsonPath("$.hasNext").value(hasNext));
     }
 
     @Test
-    @DisplayName("페이징을 포함하지 않고 그룹에 등록된 전체 쿠폰을 조회한다")
-    void getAllVoucherInGroupNoPageInfo() throws Exception {
+    @DisplayName("페이지 조건은 없고, 필터 조건은 포함하여 그룹에 등록된 전체 쿠폰을 조회한다")
+    void getAllVoucherInGroupNoPageInfoAndFilterCondition() throws Exception {
         //given
         Long groupId = 1L;
         Long cursorId = null;
@@ -440,13 +502,100 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 .build();
 
         VoucherListResponse mockResponse = VoucherListResponse.of(
-                List.of(VouchersResponse.withWishList(voucher, mockPresignedUrl, false)), userGroup);
+                List.of(VouchersResponse.withWishList(voucher, mockPresignedUrl, false)),
+                userGroup);
 
         SliceResponse<VoucherListResponse> mockSlice = SliceResponse.of(mockResponse, hasNext,
                 pageSize);
 
+        VoucherFilterCondition emptyCondition = VoucherFilterCondition.of(
+                List.of(VoucherStatus.AVAILABLE),
+                LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 31));
+
         when(voucherService.getAllVoucher(eq(mockUser.getId()), eq(groupId), eq(cursorId),
-                eq(pageSize))).thenReturn(mockSlice);
+                eq(pageSize), eq(emptyCondition))).thenReturn(mockSlice);
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/vouchers/{groupId}", groupId)
+                                .param("voucherStatuses", "AVAILABLE")
+                                .param("startDay", "2025-01-01")
+                                .param("endDay", "2025-01-31")
+                                .with(csrf())
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isNotEmpty())
+                .andExpect(jsonPath("$.size").value(pageSize))
+                .andExpect(jsonPath("$.hasNext").value(hasNext));
+
+    }
+
+    @Test
+    @DisplayName("startDay와 endDay가 yyyy-MM-dd 포맷이 아닐 경우 예외가 발생한다")
+    void getAllVoucherInGroupWithDateFormat() throws Exception {
+        //given
+        Long groupId = 1L;
+
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/vouchers/{groupId}", groupId)
+                                .param("startDay", "2025/01/01")
+                                .param("endDay", "2025/01/31")
+                                .with(csrf())
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("400"));
+
+    }
+
+    @Test
+    @DisplayName("필터 조건과 페이지 정보 모두 없이 그룹에 등록된 전체 쿠폰을 조회한다")
+    void getAllVoucherInGroupNoPageInfoAndNoFilterCondition() throws Exception {
+        //given
+        Long groupId = 1L;
+        Long cursorId = null;
+        int pageSize = 10;
+        Long userId = mockUser.getId();
+        Long voucherId = 1L;
+        boolean hasNext = false;
+        String mockPresignedUrl = "mockPresignedUrl";
+
+        User user = User.builder()
+                .id(userId)
+                .build();
+        Voucher voucher = Voucher.builder()
+                .id(voucherId)
+                .image("www.image.com")
+                .name("쿠폰 이름")
+                .user(user)
+                .expiration(LocalDate.of(2020, 1, 1))
+                .status(VoucherStatus.AVAILABLE)
+                .build();
+        Group group = Group.builder()
+                .id(groupId)
+                .inviteCode("InviteCode")
+                .build();
+        UserGroup userGroup = UserGroup.builder()
+                .user(user)
+                .group(group)
+                .groupTitleAlias("나의 그룹 이름")
+                .build();
+
+        VoucherListResponse mockResponse = VoucherListResponse.of(
+                List.of(VouchersResponse.withWishList(voucher, mockPresignedUrl, false)),
+                userGroup);
+
+        SliceResponse<VoucherListResponse> mockSlice = SliceResponse.of(mockResponse, hasNext,
+                pageSize);
+
+        VoucherFilterCondition emptyCondition = VoucherFilterCondition.of(null, null, null);
+
+        when(voucherService.getAllVoucher(eq(mockUser.getId()), eq(groupId), eq(cursorId),
+                eq(pageSize), eq(emptyCondition))).thenReturn(mockSlice);
 
         //when //then
         mockMvc.perform(
@@ -455,7 +604,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isNotEmpty())
                 .andExpect(jsonPath("$.hasNext").value(hasNext))
                 .andExpect(jsonPath("$.size").value(pageSize));
@@ -476,7 +625,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk());
+                .andExpect(status().isOk());
     }
 
     @Test
@@ -494,7 +643,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"));
     }
 
@@ -513,7 +662,7 @@ public class VoucherControllerTest extends ControllerTestSupport {
                                 .with(oauth2Login().oauth2User(mockUser))
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isBadRequest())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"));
     }
 }

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherControllerTest.java
@@ -8,6 +8,8 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
@@ -550,6 +552,24 @@ public class VoucherControllerTest extends ControllerTestSupport {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value("400"));
 
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {0L, 21L})
+    @DisplayName("전체 쿠폰 조회 시의 페이지 사이즈는 1 ~ 20 사이여야 한다")
+    void getAllVoucherInGroupWithPageSize(Long pageSize) throws Exception {
+        //given
+        Long groupId = 1L;
+        
+        //when //then
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/vouchers/{groupId}", groupId)
+                                .param("pageSize", String.valueOf(pageSize))
+                                .with(csrf())
+                                .with(oauth2Login().oauth2User(mockUser))
+                )
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherRepositoryTest.java
@@ -1,21 +1,29 @@
 package seondays.shareticon.api.voucher;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import seondays.shareticon.api.config.RepositoryTestSupport;
 import seondays.shareticon.group.Group;
 import seondays.shareticon.group.GroupRepository;
 import seondays.shareticon.user.User;
 import seondays.shareticon.user.UserRepository;
 import seondays.shareticon.voucher.Voucher;
+import seondays.shareticon.voucher.VoucherFilterCondition;
 import seondays.shareticon.voucher.VoucherRepository;
 import seondays.shareticon.voucher.VoucherStatus;
 import seondays.shareticon.voucher.dto.VoucherWithWishListResponse;
@@ -31,6 +39,18 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
     @Autowired
     private UserRepository userRepository;
 
+    @MockitoBean
+    protected Clock clock;
+
+    private Instant testSystemTimeInstant;
+
+    @BeforeEach
+    void setUp() {
+        testSystemTimeInstant = Instant.parse("2024-12-01T00:00:00Z");
+        when(clock.instant()).thenReturn(testSystemTimeInstant);
+        when(clock.getZone()).thenReturn(ZoneId.of("Asia/Seoul"));
+    }
+
     @Test
     @DisplayName("전체 쿠폰의 첫번째 페이지를 조회한다")
     void getAllVoucherWithFirstPage() {
@@ -42,20 +62,29 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        Voucher voucher1 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher2 = createVoucher(group, user, VoucherStatus.USED);
-        Voucher voucher3 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher4 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher5 = createVoucher(group, user, VoucherStatus.USED);
+        LocalDate expiration = LocalDate.of(2024, 12, 5);
+        Voucher voucher1 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher2 = createVoucherWithExpiration(group, user, VoucherStatus.USED, expiration);
+        Voucher voucher3 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher4 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher5 = createVoucherWithExpiration(group, user, VoucherStatus.USED, expiration);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
 
-        Pageable pageable = PageRequest.of(0, 2);
+        Pageable pageable = PageRequest.ofSize(2);
 
         List<VoucherStatus> voucherStatuses = VoucherStatus.forDisplayVoucherStatus();
 
-        //when
-        Slice<VoucherWithWishListResponse> firstPage = voucherRepository.findAllPageWithCursorByDesc(
-                user.getId(), group.getId(), voucherStatuses, null, pageable);
+        LocalDate searchStart = null;
+        LocalDate searchEnd = null;
+        List<VoucherStatus> status = null;
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                status, searchStart, searchEnd);
+
+        Slice<VoucherWithWishListResponse> firstPage = voucherRepository.searchVoucher(
+                user.getId(), group.getId(), voucherFilterCondition, null, pageable);
 
         //then
         assertThat(firstPage.getContent()).hasSize(pageable.getPageSize());
@@ -79,25 +108,35 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        Voucher voucher1 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher2 = createVoucher(group, user, VoucherStatus.USED);
-        Voucher voucher3 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher4 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher5 = createVoucher(group, user, VoucherStatus.USED);
+        LocalDate expiration = LocalDate.of(2024, 12, 5);
+        Voucher voucher1 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher2 = createVoucherWithExpiration(group, user, VoucherStatus.USED, expiration);
+        Voucher voucher3 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher4 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher5 = createVoucherWithExpiration(group, user, VoucherStatus.USED, expiration);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
 
-        Pageable pageable = PageRequest.of(0, 2);
+        Pageable pageable = PageRequest.ofSize(2);
 
         List<VoucherStatus> voucherStatuses = VoucherStatus.forDisplayVoucherStatus();
 
-        Slice<VoucherWithWishListResponse> firstPage = voucherRepository.findAllPageWithCursorByDesc(
-                user.getId(), group.getId(), voucherStatuses, null, pageable);
+        LocalDate searchStart = null;
+        LocalDate searchEnd = null;
+        List<VoucherStatus> status = null;
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                status, searchStart, searchEnd);
+
+        Slice<VoucherWithWishListResponse> firstPage = voucherRepository.searchVoucher(
+                user.getId(), group.getId(), voucherFilterCondition, null, pageable);
 
         Long cursor = firstPage.getContent().get(firstPage.getContent().size() - 1).id();
 
         //when
-        Slice<VoucherWithWishListResponse> secondPage = voucherRepository.findAllPageWithCursorByDesc(
-                user.getId(), group.getId(), voucherStatuses, cursor, pageable);
+        Slice<VoucherWithWishListResponse> secondPage = voucherRepository.searchVoucher(
+                user.getId(), group.getId(), voucherFilterCondition, cursor, pageable);
 
         //then
         assertThat(secondPage.getContent()).hasSize(pageable.getPageSize());
@@ -106,8 +145,8 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
                 .allMatch(v -> voucherStatuses.contains(v.status()));
         assertThat(secondPage.getContent()).isSortedAccordingTo(
                 Comparator.comparing(VoucherWithWishListResponse::id).reversed());
-        assertThat(secondPage.getContent()).extracting("id")
-                .containsExactly(voucher3.getId(), voucher2.getId());
+            assertThat(secondPage.getContent()).extracting("id")
+                    .containsExactly(voucher3.getId(), voucher2.getId());
     }
 
     @Test
@@ -121,28 +160,38 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        Voucher voucher1 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher2 = createVoucher(group, user, VoucherStatus.USED);
-        Voucher voucher3 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher4 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher5 = createVoucher(group, user, VoucherStatus.USED);
+        LocalDate expiration = LocalDate.of(2024, 12, 5);
+        Voucher voucher1 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher2 = createVoucherWithExpiration(group, user, VoucherStatus.USED, expiration);
+        Voucher voucher3 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher4 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher5 = createVoucherWithExpiration(group, user, VoucherStatus.USED, expiration);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
 
-        Pageable pageable = PageRequest.of(0, 2);
+        Pageable pageable = PageRequest.ofSize(2);
 
         List<VoucherStatus> voucherStatuses = VoucherStatus.forDisplayVoucherStatus();
 
-        Slice<VoucherWithWishListResponse> firstPage = voucherRepository.findAllPageWithCursorByDesc(
-                user.getId(), group.getId(), voucherStatuses, null, pageable);
+        LocalDate searchStart = null;
+        LocalDate searchEnd = null;
+        List<VoucherStatus> status = null;
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                status, searchStart, searchEnd);
+
+        Slice<VoucherWithWishListResponse> firstPage = voucherRepository.searchVoucher(
+                user.getId(), group.getId(), voucherFilterCondition, null, pageable);
         Long firstCursor = firstPage.getContent().get(firstPage.getContent().size() - 1).id();
 
-        Slice<VoucherWithWishListResponse> secondPage = voucherRepository.findAllPageWithCursorByDesc(
-                user.getId(), group.getId(), voucherStatuses, firstCursor, pageable);
+        Slice<VoucherWithWishListResponse> secondPage = voucherRepository.searchVoucher(
+                user.getId(), group.getId(), voucherFilterCondition, firstCursor, pageable);
         Long secondCursor = secondPage.getContent().get(secondPage.getContent().size() - 1).id();
 
         //when
-        Slice<VoucherWithWishListResponse> lastPage = voucherRepository.findAllPageWithCursorByDesc(
-                user.getId(), group.getId(), voucherStatuses, secondCursor, pageable);
+        Slice<VoucherWithWishListResponse> lastPage = voucherRepository.searchVoucher(
+                user.getId(), group.getId(), voucherFilterCondition, secondCursor, pageable);
 
         //then
         assertThat(lastPage.getContent()).hasSize(1);
@@ -154,8 +203,8 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
     }
 
     @Test
-    @DisplayName("사용가능, 사용완료, 사용만료 상태인 쿠폰만 조회된다")
-    void getVoucherStatusUsedAndAvailable() {
+    @DisplayName("상태 조건을 만족하는 쿠폰만 조회된다")
+    void getVoucherStatusCondition() {
         //given
         User user = User.builder().build();
         userRepository.save(user);
@@ -164,27 +213,75 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        Voucher voucher1 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher2 = createVoucher(group, user, VoucherStatus.USED);
-        Voucher voucher3 = createVoucher(group, user, VoucherStatus.EXPIRED);
-        Voucher voucher4 = createVoucher(group, user, VoucherStatus.AVAILABLE);
-        Voucher voucher5 = createVoucher(group, user, VoucherStatus.EXPIRED);
+        LocalDate expiration = LocalDate.of(2024, 12, 5);
+        Voucher voucher1 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher2 = createVoucherWithExpiration(group, user, VoucherStatus.USED, expiration);
+        Voucher voucher3 = createVoucherWithExpiration(group, user, VoucherStatus.EXPIRED,
+                expiration);
+        Voucher voucher4 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiration);
+        Voucher voucher5 = createVoucherWithExpiration(group, user, VoucherStatus.USED, expiration);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
 
-        List<VoucherStatus> voucherStatuses = VoucherStatus.forDisplayVoucherStatus();
+        Pageable pageable = PageRequest.ofSize(5);
 
-        Pageable pageable = PageRequest.of(0, 5);
+        LocalDate searchStart = null;
+        LocalDate searchEnd = null;
+        List<VoucherStatus> status = List.of(VoucherStatus.AVAILABLE);
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                status, searchStart, searchEnd);
 
         //when
-        Slice<VoucherWithWishListResponse> result =
-                voucherRepository.findAllPageWithCursorByDesc(user.getId(),
-                group.getId(), voucherStatuses, null, pageable);
+        Slice<VoucherWithWishListResponse> result = voucherRepository.searchVoucher(
+                user.getId(), group.getId(), voucherFilterCondition, null, pageable);
 
         //then
         assertThat(result.getContent()).extracting("status")
-                .containsExactlyInAnyOrder(
-                        VoucherStatus.AVAILABLE, VoucherStatus.USED, VoucherStatus.EXPIRED,
-                        VoucherStatus.AVAILABLE, VoucherStatus.EXPIRED);
+                .contains(VoucherStatus.AVAILABLE, VoucherStatus.AVAILABLE);
+    }
+
+    @Test
+    @DisplayName("만료 기간 조건을 만족하는 쿠폰만 조회된다")
+    void getVoucherExpiredCondition() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
+        groupRepository.save(group);
+
+        LocalDate expiredConditionDate = LocalDate.of(2024, 11, 5);
+        LocalDate notExpiredConditionDate = LocalDate.of(2024, 12, 5);
+        Voucher voucher1 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                expiredConditionDate);
+        Voucher voucher2 = createVoucherWithExpiration(group, user, VoucherStatus.USED,
+                notExpiredConditionDate);
+        Voucher voucher3 = createVoucherWithExpiration(group, user, VoucherStatus.EXPIRED,
+                expiredConditionDate);
+        Voucher voucher4 = createVoucherWithExpiration(group, user, VoucherStatus.AVAILABLE,
+                notExpiredConditionDate);
+        Voucher voucher5 = createVoucherWithExpiration(group, user, VoucherStatus.USED,
+                notExpiredConditionDate);
+        voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3, voucher4, voucher5));
+
+        Pageable pageable = PageRequest.ofSize(5);
+
+        LocalDate searchStart = LocalDate.of(2024,12,1);
+        LocalDate searchEnd = LocalDate.of(2024,12,10);
+        List<VoucherStatus> status = null;
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                status, searchStart, searchEnd);
+
+        //when
+        Slice<VoucherWithWishListResponse> result = voucherRepository.searchVoucher(
+                user.getId(), group.getId(), voucherFilterCondition, null, pageable);
+
+        //then
+        assertThat(result.getContent()).extracting("id")
+                .containsExactlyInAnyOrder(voucher2.getId(), voucher4.getId(), voucher5.getId());
+
     }
 
     @Test
@@ -196,14 +293,17 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
         Group group = createTestGroup(inviteCode);
         groupRepository.save(group);
 
-        Pageable pageable = PageRequest.of(0, 2);
+        Pageable pageable = PageRequest.ofSize(2);
 
-        List<VoucherStatus> voucherStatuses = VoucherStatus.forDisplayVoucherStatus();
+        LocalDate searchStart = null;
+        LocalDate searchEnd = null;
+        List<VoucherStatus> status = List.of(VoucherStatus.AVAILABLE);
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                status, searchStart, searchEnd);
 
         //when
-        Slice<VoucherWithWishListResponse> result =
-                voucherRepository.findAllPageWithCursorByDesc(userId,
-                        group.getId(), voucherStatuses, null, pageable);
+        Slice<VoucherWithWishListResponse> result = voucherRepository.searchVoucher(
+                userId, group.getId(), voucherFilterCondition, null, pageable);
 
         //then
         assertThat(result.getContent()).isEmpty();
@@ -266,14 +366,17 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
                 .status(VoucherStatus.AVAILABLE).build();
         voucherRepository.save(voucher);
 
-        List<VoucherStatus> voucherStatuses = VoucherStatus.forDisplayVoucherStatus();
+        Pageable pageable = PageRequest.ofSize(2);
 
-        Pageable pageable = PageRequest.of(0, 2);
+        LocalDate searchStart = null;
+        LocalDate searchEnd = null;
+        List<VoucherStatus> status = List.of(VoucherStatus.AVAILABLE);
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                status, searchStart, searchEnd);
 
         //when
-        Slice<VoucherWithWishListResponse> result =
-                voucherRepository.findAllPageWithCursorByDesc(user.getId(),
-                        group.getId(), voucherStatuses, null, pageable);
+        Slice<VoucherWithWishListResponse> result = voucherRepository.searchVoucher(
+                user.getId(), group.getId(), voucherFilterCondition, null, pageable);
 
         //then
         assertThat(result.getContent()).isEmpty();
@@ -281,12 +384,14 @@ class VoucherRepositoryTest extends RepositoryTestSupport {
 
     }
 
-    private static Voucher createVoucher(Group group, User user, VoucherStatus status) {
+    private static Voucher createVoucherWithExpiration(Group group, User user, VoucherStatus status,
+            LocalDate expiration) {
         return Voucher.builder()
                 .user(user)
                 .group(group)
                 .isDeleted(false)
                 .status(status)
+                .expiration(expiration)
                 .build();
     }
 

--- a/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
+++ b/src/test/java/seondays/shareticon/api/voucher/VoucherServiceTest.java
@@ -45,6 +45,7 @@ import seondays.shareticon.userGroup.UserGroup;
 import seondays.shareticon.userGroup.UserGroupRepository;
 import seondays.shareticon.utils.SliceResponse;
 import seondays.shareticon.voucher.Voucher;
+import seondays.shareticon.voucher.VoucherFilterCondition;
 import seondays.shareticon.voucher.VoucherRepository;
 import seondays.shareticon.voucher.VoucherService;
 import seondays.shareticon.voucher.VoucherStatus;
@@ -309,7 +310,8 @@ class VoucherServiceTest extends IntegrationTestSupport {
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
 
-        Voucher voucher = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
+        Voucher voucher = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                expiration);
         voucherRepository.save(voucher);
 
         //when
@@ -396,18 +398,26 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
-        Voucher voucher1 = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
-        Voucher voucher2 = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
-        Voucher voucher3 = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
+        Voucher voucher1 = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                expiration);
+        Voucher voucher2 = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                expiration);
+        Voucher voucher3 = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                expiration);
 
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
+
+        LocalDate searchStart = LocalDate.of(2024, 12, 10);
+        LocalDate searchEnd = LocalDate.of(2025, 1, 10);
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                VoucherStatus.forDisplayVoucherStatus(), searchStart, searchEnd);
 
         //when
         String preSignedImageUrl = "presignedImageUrlResult";
         given(imageService.getPresignedImageUrl(any(), any())).willReturn(preSignedImageUrl);
 
         SliceResponse<VoucherListResponse> allVoucher = voucherService.getAllVoucher(user.getId(),
-                group.getId(), null, 3);
+                group.getId(), null, 3, voucherFilterCondition);
 
         VoucherListResponse voucherListResponse = allVoucher.getContent().get(0);
 
@@ -442,9 +452,14 @@ class VoucherServiceTest extends IntegrationTestSupport {
         String userGroupAlias = "그룹 별칭";
         linkUserWithGroup(user, group, userGroupAlias);
 
+        LocalDate searchStart = LocalDate.of(2024, 12, 10);
+        LocalDate searchEnd = LocalDate.of(2025, 1, 10);
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                VoucherStatus.forDisplayVoucherStatus(), searchStart, searchEnd);
+
         //when
         SliceResponse<VoucherListResponse> allVoucher = voucherService.getAllVoucher(user.getId(),
-                group.getId(), null, 3);
+                group.getId(), null, 3, voucherFilterCondition);
 
         VoucherListResponse voucherListResponse = allVoucher.getContent().get(0);
 
@@ -469,15 +484,215 @@ class VoucherServiceTest extends IntegrationTestSupport {
         groupRepository.save(group);
 
         LocalDate expiration = LocalDate.of(2025, 1, 1);
-        Voucher voucher1 = Voucher.createNewVoucher(user, group, "voucher name1", "imageKey", expiration);
-        Voucher voucher2 = Voucher.createNewVoucher(user, group, "voucher name2", "imageKey", expiration);
-        Voucher voucher3 = Voucher.createNewVoucher(user, group, "voucher name3", "imageKey", expiration);
+        Voucher voucher1 = Voucher.createNewVoucher(user, group, "voucher name1", "imageKey",
+                expiration);
+        Voucher voucher2 = Voucher.createNewVoucher(user, group, "voucher name2", "imageKey",
+                expiration);
+        Voucher voucher3 = Voucher.createNewVoucher(user, group, "voucher name3", "imageKey",
+                expiration);
         voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
+
+        LocalDate searchStart = LocalDate.of(2024, 12, 10);
+        LocalDate searchEnd = LocalDate.of(2025, 1, 10);
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                VoucherStatus.forDisplayVoucherStatus(), searchStart, searchEnd);
 
         //when //then
         assertThatThrownBy(() -> voucherService.getAllVoucher(user.getId(),
-                group.getId(), null, 3)).isInstanceOf(InvalidAccessException.class);
+                group.getId(), null, 3, voucherFilterCondition)).isInstanceOf(
+                InvalidAccessException.class);
     }
+
+    @Test
+    @DisplayName("만료일 필터 : 만료일 필터를 설정하여 쿠폰을 조회할 경우, 지정한 날짜 내에 해당되는 쿠폰만 결과에 포함된다")
+    void getAllVoucherWithExpiredFilter() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
+        groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
+        UserGroup userGroup = linkUserWithGroup(user, group, userGroupAlias);
+
+        String voucherName = "voucher name";
+        Voucher voucher1 = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                LocalDate.of(2025, 1, 1));
+        Voucher voucher2 = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                LocalDate.of(2025, 3, 1));
+        Voucher voucher3 = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                LocalDate.of(2025, 2, 15));
+        voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
+
+        LocalDate searchStart = LocalDate.of(2025, 1, 1);
+        LocalDate searchEnd = LocalDate.of(2025, 2, 28);
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                VoucherStatus.forDisplayVoucherStatus(), searchStart, searchEnd);
+
+        //when
+        String preSignedImageUrl = "presignedImageUrlResult";
+        given(imageService.getPresignedImageUrl(any(), any())).willReturn(preSignedImageUrl);
+
+        SliceResponse<VoucherListResponse> allVoucher = voucherService.getAllVoucher(user.getId(),
+                group.getId(), null, 3, voucherFilterCondition);
+
+        VoucherListResponse content = allVoucher.getContent().get(0);
+
+        //then
+        assertThat(allVoucher).isNotNull();
+        assertThat(allVoucher.getSize()).isEqualTo(3);
+        assertThat(allVoucher.getContent().size()).isEqualTo(1);
+
+        assertThat(content).isNotNull();
+        assertThat(content.vouchers()).hasSize(2);
+        assertThat(content.vouchers())
+                .extracting(VouchersResponse::id)
+                .containsExactlyInAnyOrder(voucher1.getId(), voucher3.getId())
+                .doesNotContain(voucher2.getId());
+
+    }
+
+    @Test
+    @DisplayName("만료일 필터 : 만료일 필터 내역을 설정하지 않고 쿠폰을 조회할 경우, 조회일로부터 30일 이내로 만료되는 쿠폰만 결과에 포함된다")
+    void getAllVoucherWithDefaultExpiredFilter() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
+        groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
+        UserGroup userGroup = linkUserWithGroup(user, group, userGroupAlias);
+
+        String voucherName = "voucher name";
+        Voucher voucher1 = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                LocalDate.of(2024, 12, 31));
+        Voucher voucher2 = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                LocalDate.of(2024, 11, 30));
+        Voucher voucher3 = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                LocalDate.of(2025, 1, 1));
+        voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
+
+        LocalDate searchStart = null;
+        LocalDate searchEnd = null;
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                VoucherStatus.forDisplayVoucherStatus(), searchStart, searchEnd);
+
+        //when
+        String preSignedImageUrl = "presignedImageUrlResult";
+        given(imageService.getPresignedImageUrl(any(), any())).willReturn(preSignedImageUrl);
+
+        SliceResponse<VoucherListResponse> allVoucher = voucherService.getAllVoucher(user.getId(),
+                group.getId(), null, 3, voucherFilterCondition);
+
+        VoucherListResponse content = allVoucher.getContent().get(0);
+
+        //then
+        assertThat(content).isNotNull();
+        assertThat(content.vouchers()).hasSize(1);
+        assertThat(content.vouchers())
+                .extracting(VouchersResponse::id)
+                .containsExactlyInAnyOrder(voucher1.getId())
+                .doesNotContain(voucher2.getId(), voucher3.getId());
+
+    }
+
+    @Test
+    @DisplayName("쿠폰 상태 필터 : 쿠폰 상태 필터를 설정하여 쿠폰을 조회할 경우, 설정한 상태의 쿠폰만 결과에 포함된다")
+    void getAllVoucherWithStatusFilter() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
+        groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
+        UserGroup userGroup = linkUserWithGroup(user, group, userGroupAlias);
+
+        LocalDate expiration = LocalDate.of(2024, 12, 31);
+        Voucher voucher1 = Voucher.builder().user(user).group(group).expiration(expiration)
+                .status(VoucherStatus.AVAILABLE).build();
+        Voucher voucher2 = Voucher.builder().user(user).group(group).expiration(expiration)
+                .status(VoucherStatus.EXPIRED).build();
+        Voucher voucher3 = Voucher.builder().user(user).group(group).expiration(expiration)
+                .status(VoucherStatus.USED).build();
+        voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
+
+        LocalDate searchStart = null;
+        LocalDate searchEnd = null;
+        List<VoucherStatus> status = List.of(VoucherStatus.EXPIRED);
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                status, searchStart, searchEnd);
+
+        //when
+        String preSignedImageUrl = "presignedImageUrlResult";
+        given(imageService.getPresignedImageUrl(any(), any())).willReturn(preSignedImageUrl);
+
+        SliceResponse<VoucherListResponse> allVoucher = voucherService.getAllVoucher(user.getId(),
+                group.getId(), null, 3, voucherFilterCondition);
+
+        VoucherListResponse content = allVoucher.getContent().get(0);
+
+        //then
+        assertThat(content).isNotNull();
+        assertThat(content.vouchers())
+                .extracting(VouchersResponse::id)
+                .contains(voucher2.getId());
+
+    }
+
+    @Test
+    @DisplayName("쿠폰 상태 필터 : 쿠폰 상태 필터를 설정하지 않고 쿠폰을 조회할 경우, 사용가능, 사용완료 상태인 쿠폰만 결과에 조회된다")
+    void getAllVoucherWithDefaultStatusFilter() {
+        //given
+        User user = User.builder().build();
+        userRepository.save(user);
+
+        String inviteCode = "ABC";
+        Group group = createTestGroup(inviteCode);
+        groupRepository.save(group);
+
+        String userGroupAlias = "그룹 별칭";
+        UserGroup userGroup = linkUserWithGroup(user, group, userGroupAlias);
+
+        LocalDate expiration = LocalDate.of(2024, 12, 31);
+        Voucher voucher1 = Voucher.builder().user(user).group(group).expiration(expiration)
+                .status(VoucherStatus.AVAILABLE).build();
+        Voucher voucher2 = Voucher.builder().user(user).group(group).expiration(expiration)
+                .status(VoucherStatus.EXPIRED).build();
+        Voucher voucher3 = Voucher.builder().user(user).group(group).expiration(expiration)
+                .status(VoucherStatus.USED).build();
+        voucherRepository.saveAll(List.of(voucher1, voucher2, voucher3));
+
+        LocalDate searchStart = null;
+        LocalDate searchEnd = null;
+        List<VoucherStatus> status = null;
+        VoucherFilterCondition voucherFilterCondition = VoucherFilterCondition.of(
+                status, searchStart, searchEnd);
+
+        //when
+        String preSignedImageUrl = "presignedImageUrlResult";
+        given(imageService.getPresignedImageUrl(any(), any())).willReturn(preSignedImageUrl);
+
+        SliceResponse<VoucherListResponse> allVoucher = voucherService.getAllVoucher(user.getId(),
+                group.getId(), null, 3, voucherFilterCondition);
+
+        VoucherListResponse content = allVoucher.getContent().get(0);
+
+        //then
+        assertThat(content).isNotNull();
+        assertThat(content.vouchers())
+                .extracting(VouchersResponse::id)
+                .contains(voucher1.getId(), voucher3.getId());
+
+    }
+
 
     @TestFactory
     @Transactional
@@ -496,7 +711,8 @@ class VoucherServiceTest extends IntegrationTestSupport {
 
         String voucherName = "voucher name";
         LocalDate expiration = LocalDate.of(2025, 1, 1);
-        Voucher voucher = Voucher.createNewVoucher(user, group, voucherName, "imageKey", expiration);
+        Voucher voucher = Voucher.createNewVoucher(user, group, voucherName, "imageKey",
+                expiration);
         voucherRepository.save(voucher);
 
         return Stream.of(

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -259,7 +259,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                         .type(JsonFieldType.STRING).description("쿠폰 이미지 URL"),
                                 fieldWithPath("content[].vouchers[].status")
                                         .type(JsonFieldType.STRING)
-                                        .description("쿠폰 사용 상태 (AVAILABLE/EXPIRED/USED)"),
+                                        .description("쿠폰 사용 상태. 다중 선택 가능 (AVAILABLE/EXPIRED/USED)"),
                                 fieldWithPath("content[].vouchers[].registeredUserId")
                                         .type(JsonFieldType.NUMBER).description("쿠폰을 등록한 유저의 ID"),
                                 fieldWithPath("content[].vouchers[].name")

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -268,9 +268,6 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("content[].vouchers[].expiration")
                                         .type(JsonFieldType.STRING)
                                         .description("쿠폰 등록자가 설정한 쿠폰의 만료 기간"),
-                                fieldWithPath("content[].vouchers[].status").type(
-                                                JsonFieldType.STRING)
-                                        .description("쿠폰의 현재 상태"),
                                 fieldWithPath("content[].vouchers[].isWishList").type(
                                                 JsonFieldType.BOOLEAN)
                                         .description("쿠폰이 찜 되어 있는지의 여부"),

--- a/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
+++ b/src/test/java/seondays/shareticon/docs/voucher/VoucherControllerDocsTest.java
@@ -11,7 +11,6 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.subsectionWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -19,6 +18,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 import java.nio.charset.StandardCharsets;
@@ -41,6 +41,7 @@ import seondays.shareticon.userGroup.UserGroup;
 import seondays.shareticon.utils.SliceResponse;
 import seondays.shareticon.voucher.Voucher;
 import seondays.shareticon.voucher.VoucherController;
+import seondays.shareticon.voucher.VoucherFilterCondition;
 import seondays.shareticon.voucher.VoucherService;
 import seondays.shareticon.voucher.VoucherStatus;
 import seondays.shareticon.voucher.dto.CreateVoucherRequest;
@@ -166,14 +167,14 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
     }
 
     @Test
-    @DisplayName("페이징을 포함하여 그룹에 등록된 전체 쿠폰을 조회한다")
-    void getAllVoucherInGroup() throws Exception {
+    @DisplayName("필터 조건과 페이지 정보 모두 포함하여 그룹에 등록된 전체 쿠폰을 조회한다")
+    void getAllVoucherInGroupPageInfoAndFilterCondition() throws Exception {
         //given
         Long groupId = 1L;
-        Long cursorId = null;
-        int pageSize = 10;
         Long userId = mockUser.getId();
         Long voucherId = 1L;
+        Long cursorId = 1L;
+        int pageSize = 1;
         boolean hasNext = false;
         String mockPresignedUrl = "mockPresignedUrl";
 
@@ -197,28 +198,36 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                 .group(group)
                 .groupTitleAlias("나의 그룹 이름")
                 .build();
-
         VoucherListResponse mockResponse = VoucherListResponse.of(
-                List.of(VouchersResponse.withWishList(voucher, mockPresignedUrl, true)), userGroup);
+                List.of(VouchersResponse.withWishList(voucher, mockPresignedUrl, false)),
+                userGroup);
 
         SliceResponse<VoucherListResponse> mockSlice = SliceResponse.of(mockResponse, hasNext,
                 pageSize);
 
+        VoucherFilterCondition emptyCondition = VoucherFilterCondition.of(
+                List.of(VoucherStatus.AVAILABLE),
+                LocalDate.of(2025, 1, 1), LocalDate.of(2025, 1, 31));
+
         when(voucherService.getAllVoucher(eq(mockUser.getId()), eq(groupId), eq(cursorId),
-                eq(pageSize))).thenReturn(mockSlice);
+                eq(pageSize), eq(emptyCondition))).thenReturn(mockSlice);
 
         //when //then
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/api/vouchers/{groupId}", groupId)
+                                .param("cursorId", cursorId.toString())
+                                .param("pageSize", String.valueOf(pageSize))
+                                .param("voucherStatuses", "AVAILABLE")
+                                .param("startDay", "2025-01-01")
+                                .param("endDay", "2025-01-31")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .with(addBearerToken())
                 )
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isNotEmpty())
-                .andExpect(jsonPath("$.hasNext").value(hasNext))
                 .andExpect(jsonPath("$.size").value(pageSize))
-
+                .andExpect(jsonPath("$.hasNext").value(hasNext))
                 .andDo(document("voucher-get",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
@@ -228,7 +237,13 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                         queryParameters(
                                 parameterWithName("cursorId").description("커서 ID 값").optional(),
                                 parameterWithName("pageSize").description("페이지 사이즈 값 (기본값 10)")
-                                        .optional()
+                                        .optional(),
+                                parameterWithName("voucherStatuses").description(
+                                        "조회할 쿠폰의 사용 상태 (AVAILABLE/EXPIRED/USED)").optional(),
+                                parameterWithName("startDay").description(
+                                        "만료일 기준으로 쿠폰을 조회하는 기간의 시작일 (yyyy-MM-dd)").optional(),
+                                parameterWithName("endDay").description(
+                                        "만료일 기준으로 쿠폰을 조회하는 기간의 종료일 (yyyy-MM-dd)").optional()
                         ),
                         responseFields(
                                 fieldWithPath("content").type(JsonFieldType.ARRAY)
@@ -248,12 +263,16 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("content[].vouchers[].registeredUserId")
                                         .type(JsonFieldType.NUMBER).description("쿠폰을 등록한 유저의 ID"),
                                 fieldWithPath("content[].vouchers[].name")
-                                        .type(JsonFieldType.STRING).description("쿠폰 등록자가 설정한 쿠폰의 이름"),
+                                        .type(JsonFieldType.STRING)
+                                        .description("쿠폰 등록자가 설정한 쿠폰의 이름"),
                                 fieldWithPath("content[].vouchers[].expiration")
-                                        .type(JsonFieldType.STRING).description("쿠폰 등록자가 설정한 쿠폰의 만료 기간"),
-                                fieldWithPath("content[].vouchers[].status").type(JsonFieldType.STRING)
+                                        .type(JsonFieldType.STRING)
+                                        .description("쿠폰 등록자가 설정한 쿠폰의 만료 기간"),
+                                fieldWithPath("content[].vouchers[].status").type(
+                                                JsonFieldType.STRING)
                                         .description("쿠폰의 현재 상태"),
-                                fieldWithPath("content[].vouchers[].isWishList").type(JsonFieldType.BOOLEAN)
+                                fieldWithPath("content[].vouchers[].isWishList").type(
+                                                JsonFieldType.BOOLEAN)
                                         .description("쿠폰이 찜 되어 있는지의 여부"),
 
                                 fieldWithPath("hasNext").type(JsonFieldType.BOOLEAN)
@@ -261,6 +280,7 @@ public class VoucherControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("size").type(JsonFieldType.NUMBER)
                                         .description("요청한 페이지의 사이즈")
                         )));
+
     }
 
     @Test


### PR DESCRIPTION
## 연관 이슈
#51 

## 작업 내용
- 쿠폰 조회 시 QueryDsl을 이용한 동적 쿼리 사용하도록 변경
- 조회 시 쿼리 파라미터로 필터링 조건 추가하도록 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 그룹 내 바우처 조회에 상태·기간 필터(VoucherFilterCondition)와 커서 기반 페이징을 지원합니다.
- Refactor
  - 바우처 조회를 QueryDSL 기반 검색으로 전환하고 JPAQueryFactory 빈을 도입했습니다.
- Bug Fixes
  - 만료일 검증을 오늘 포함(FutureOrPresent)으로 완화, pageSize 경계 검사를 추가하고 제약 위반 시 BAD_REQUEST 처리 핸들러를 도입했습니다.
- Documentation
  - 바우처 조회 API 문서에 필터 및 페이징 파라미터를 추가했습니다.
- Tests
  - 필터/페이징 시나리오 테스트 확대, 테스트용 QueryDSL 설정 및 고정된 Clock 지원을 추가했습니다.
- Chores
  - 빌드에 QueryDSL 의존성·생성 경로 통합 및 정리 작업을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->